### PR TITLE
26 allow trial selection for decoding

### DIFF
--- a/bayes_replay_decoding.py
+++ b/bayes_replay_decoding.py
@@ -81,6 +81,18 @@ if __name__ == '__main__':
 	bin_time = 0.1 #Seconds to skip forward in calculating firing rates
 	bin_dt = np.ceil(bin_time*1000).astype('int')
 	
+	#%% Get FR distributions
+	
+	tastant_fr_dist_pop, max_hz_pop, taste_num_deliv = df.taste_fr_dist(num_neur,num_cp,tastant_spike_times,
+														 taste_cp_raster_inds,pop_taste_cp_raster_inds,
+														 start_dig_in_times, pre_taste_dt, post_taste_dt)
+	
+	tastant_fr_dist_pop_z, max_hz_pop, min_hz_pop, taste_num_deliv_z = df.taste_fr_dist_zscore(num_neur,num_cp,tastant_spike_times,
+																segment_spike_times,segment_names,segment_times,
+																taste_cp_raster_inds,pop_taste_cp_raster_inds,
+																start_dig_in_times, pre_taste_dt, post_taste_dt, bin_dt)
+	
+	
 	#%%
 	
 	#_____DECODE ALL NEURONS_____
@@ -93,20 +105,7 @@ if __name__ == '__main__':
 	#Get FR Distributions
 	taste_select = np.ones(num_neur) #stand in to use full population
 	taste_select_epoch = np.ones((num_cp,num_neur)) #stand in to use full population
-	full_taste_fr_dist, tastant_fr_dist, tastant_fr_dist_pop, \
-		taste_num_deliv, max_hz, max_hz_pop, max_hz_full = df.taste_fr_dist(num_neur,num_cp,tastant_spike_times,
-														 taste_cp_raster_inds,pop_taste_cp_raster_inds,
-														 start_dig_in_times, pre_taste_dt, post_taste_dt)
 	
-	#If first run full-taste decode and use only the decoded periods for the epoch decode, set to 1, else 0
-	
-	if use_full == 1:
-		#Decode by segment for a sliding post-taste bin size first
-		#___Decode using full taste response___
-		df.decode_full(full_taste_fr_dist,segment_spike_times,post_taste_dt,
-					   skip_dt,dig_in_names,segment_times,segment_names,
-					   start_dig_in_times,taste_num_deliv,taste_select,max_hz_full,bayes_dir_all)
-
 	#___Decode using epoch-specific responses___
 	df.decode_epochs(tastant_fr_dist_pop,segment_spike_times,post_taste_dt,
 					   skip_dt,e_skip_dt,e_len_dt,dig_in_names,segment_times,
@@ -115,24 +114,23 @@ if __name__ == '__main__':
 	
 	
 	#___Plot Results___
-	
-	df.plot_decoded(tastant_fr_dist,num_tastes,num_neur,num_cp,segment_spike_times,tastant_spike_times,
+	df.plot_decoded(tastant_fr_dist_pop,num_tastes,num_neur,num_cp,segment_spike_times,tastant_spike_times,
 					 start_dig_in_times,end_dig_in_times,post_taste_dt,pop_taste_cp_raster_inds,
 					 e_skip_dt,e_len_dt,dig_in_names,segment_times,
 					 segment_names,taste_num_deliv,taste_select_epoch,
 					 use_full,bayes_dir_all,max_decode,max_hz_pop,seg_stat_bin,neuron_count_thresh)
 	
-	df.plot_decoded_func_p(tastant_fr_dist,num_tastes,num_neur,num_cp,segment_spike_times,tastant_spike_times,
+	df.plot_decoded_func_p(tastant_fr_dist_pop,num_tastes,num_neur,num_cp,segment_spike_times,tastant_spike_times,
 					 start_dig_in_times,end_dig_in_times,post_taste_dt,pop_taste_cp_raster_inds,
 					 e_skip_dt,e_len_dt,dig_in_names,segment_times,
 					 segment_names,taste_num_deliv,taste_select_epoch,
-					 use_full,bayes_dir_all,max_decode,max_hz,seg_stat_bin)
+					 use_full,bayes_dir_all,max_decode,max_hz_pop,seg_stat_bin)
 	
-	df.plot_decoded_func_n(tastant_fr_dist,num_tastes,num_neur,num_cp,segment_spike_times,tastant_spike_times,
+	df.plot_decoded_func_n(tastant_fr_dist_pop,num_tastes,num_neur,num_cp,segment_spike_times,tastant_spike_times,
 					 start_dig_in_times,end_dig_in_times,post_taste_dt,pop_taste_cp_raster_inds,
 					 e_skip_dt,e_len_dt,dig_in_names,segment_times,
 					 segment_names,taste_num_deliv,taste_select_epoch,
-					 use_full,bayes_dir_all,max_decode,max_hz,seg_stat_bin)
+					 use_full,bayes_dir_all,max_decode,max_hz_pop,seg_stat_bin)
 
 #%%	
 	#_____DECODE TASTE SELECTIVE NEURONS_____
@@ -150,21 +148,6 @@ if __name__ == '__main__':
 	if os.path.isdir(bayes_dir_select) == False:
 		os.mkdir(bayes_dir_select)
 	
-	#Get FR Distributions
-	full_taste_fr_dist, tastant_fr_dist, tastant_fr_dist_pop, \
-		taste_num_deliv, max_hz, max_hz_pop, max_hz_full  = df.taste_fr_dist(num_neur,num_cp,tastant_spike_times,
-														  taste_cp_raster_inds,pop_taste_cp_raster_inds,
-														  start_dig_in_times, pre_taste_dt, post_taste_dt)
-	
-	#Assumes the parameters are the same from all neurons above
-	if use_full == 1:
-		#Decode by segment for a sliding post-taste bin size first
-		#___Decode using full taste response___
-		df.decode_full(full_taste_fr_dist,segment_spike_times,post_taste_dt,
-				   skip_dt,dig_in_names,segment_times,segment_names,
-				   start_dig_in_times,taste_num_deliv,taste_select_neur_bin,max_hz_full,bayes_dir_select)
-
-	#___Phase 2: Decode using epoch-specific responses___
 	df.decode_epochs(tastant_fr_dist_pop,segment_spike_times,post_taste_dt,
 					   skip_dt,e_skip_dt,e_len_dt,dig_in_names,segment_times,
 					   segment_names,start_dig_in_times,taste_num_deliv,
@@ -172,23 +155,23 @@ if __name__ == '__main__':
 	
 	#___Plot Results___
 					
-	df.plot_decoded(tastant_fr_dist,num_tastes,num_neur,num_cp,segment_spike_times,tastant_spike_times,
+	df.plot_decoded(tastant_fr_dist_pop,num_tastes,num_neur,num_cp,segment_spike_times,tastant_spike_times,
 					     start_dig_in_times,end_dig_in_times,post_taste_dt,pop_taste_cp_raster_inds,
 						  e_skip_dt,e_len_dt,dig_in_names,segment_times,
 						   segment_names,taste_num_deliv,taste_select_epoch,
 						    use_full,bayes_dir_select,max_decode,max_hz_pop,seg_stat_bin,neuron_count_thresh)
 	
-	df.plot_decoded_func_p(tastant_fr_dist,num_tastes,num_neur,num_cp,segment_spike_times,tastant_spike_times,
+	df.plot_decoded_func_p(tastant_fr_dist_pop,num_tastes,num_neur,num_cp,segment_spike_times,tastant_spike_times,
 					 start_dig_in_times,end_dig_in_times,post_taste_dt,pop_taste_cp_raster_inds,
 					 e_skip_dt,e_len_dt,dig_in_names,segment_times,
 					 segment_names,taste_num_deliv,taste_select_epoch,
-					 use_full,bayes_dir_select,max_decode,max_hz,seg_stat_bin)
+					 use_full,bayes_dir_select,max_decode,max_hz_pop,seg_stat_bin)
 	
-	df.plot_decoded_func_n(tastant_fr_dist,num_tastes,num_neur,num_cp,segment_spike_times,tastant_spike_times,
+	df.plot_decoded_func_n(tastant_fr_dist_pop,num_tastes,num_neur,num_cp,segment_spike_times,tastant_spike_times,
 					 start_dig_in_times,end_dig_in_times,post_taste_dt,pop_taste_cp_raster_inds,
 					 e_skip_dt,e_len_dt,dig_in_names,segment_times,
 					 segment_names,taste_num_deliv,taste_select_epoch,
-					 use_full,bayes_dir_select,max_decode,max_hz,seg_stat_bin)
+					 use_full,bayes_dir_select,max_decode,max_hz_pop,seg_stat_bin)
 	
 #%%
 	#_____DECODE ALL NEURONS Z-SCORED_____
@@ -201,44 +184,32 @@ if __name__ == '__main__':
 	#Get FZ-Scored R Distributions
 	taste_select = np.ones(num_neur) #stand in to use full population
 	taste_select_epoch = np.ones((num_cp,num_neur)) #stand in to use full population
-	full_taste_fr_dist_z, tastant_fr_dist_z, tastant_fr_dist_pop_z, taste_num_deliv_z, \
-		max_hz, max_hz_pop, max_hz_full, min_hz, min_hz_pop, min_hz_full = df.taste_fr_dist_zscore(num_neur,num_cp,tastant_spike_times,
-																segment_spike_times,segment_names,segment_times,
-																taste_cp_raster_inds,pop_taste_cp_raster_inds,
-																start_dig_in_times, pre_taste_dt, post_taste_dt, bin_dt)
 	
-	if use_full == 1:
-		#Decode by segment for a sliding post-taste bin size first
-		#___Decode using full taste response___
-		df.decode_full_zscore(full_taste_fr_dist_z,segment_spike_times,post_taste_dt,
-						   skip_dt,dig_in_names,segment_times,segment_names,bin_dt,
-						   start_dig_in_times,taste_num_deliv,taste_select,max_hz_full,min_hz_full,bayes_dir_all_z)
-		
-	#___Phase 2: Decode using epoch-specific responses___
 	df.decode_epochs_zscore(tastant_fr_dist_pop_z,segment_spike_times,post_taste_dt,
 					   skip_dt,e_skip_dt,e_len_dt,dig_in_names,segment_times,bin_dt,
-					   segment_names,start_dig_in_times,taste_num_deliv,
+					   segment_names,start_dig_in_times,taste_num_deliv_z,
 					   taste_select_epoch,use_full,max_hz_pop,min_hz_pop,bayes_dir_all_z)
 	
-	#___Plot Results___
+	tastant_fr_dist_pop_z, max_hz_pop, min_hz_pop, taste_num_deliv_z
 	
-	df.plot_decoded(tastant_fr_dist,num_tastes,num_neur,num_cp,segment_spike_times,tastant_spike_times,
+	#___Plot Results___
+	df.plot_decoded(tastant_fr_dist_pop_z,num_tastes,num_neur,num_cp,segment_spike_times,tastant_spike_times,
 					     start_dig_in_times,end_dig_in_times,post_taste_dt,pop_taste_cp_raster_inds,
 						  e_skip_dt,e_len_dt,dig_in_names,segment_times,
-						   segment_names,taste_num_deliv,taste_select_epoch,
+						   segment_names,taste_num_deliv_z,taste_select_epoch,
 						    use_full,bayes_dir_all_z,max_decode,max_hz_pop,seg_stat_bin,neuron_count_thresh)
 	
-	df.plot_decoded_func_p(tastant_fr_dist,num_tastes,num_neur,num_cp,segment_spike_times,tastant_spike_times,
+	df.plot_decoded_func_p(tastant_fr_dist_pop_z,num_tastes,num_neur,num_cp,segment_spike_times,tastant_spike_times,
 					 start_dig_in_times,end_dig_in_times,post_taste_dt,pop_taste_cp_raster_inds,
 					 e_skip_dt,e_len_dt,dig_in_names,segment_times,
-					 segment_names,taste_num_deliv,taste_select_epoch,
-					 use_full,bayes_dir_all_z,max_decode,max_hz,seg_stat_bin)
+					 segment_names,taste_num_deliv_z,taste_select_epoch,
+					 use_full,bayes_dir_all_z,max_decode,max_hz_pop,seg_stat_bin)
 	
-	df.plot_decoded_func_n(tastant_fr_dist,num_tastes,num_neur,num_cp,segment_spike_times,tastant_spike_times,
+	df.plot_decoded_func_n(tastant_fr_dist_pop_z,num_tastes,num_neur,num_cp,segment_spike_times,tastant_spike_times,
 					 start_dig_in_times,end_dig_in_times,post_taste_dt,pop_taste_cp_raster_inds,
 					 e_skip_dt,e_len_dt,dig_in_names,segment_times,
-					 segment_names,taste_num_deliv,taste_select_epoch,
-					 use_full,bayes_dir_all_z,max_decode,max_hz,seg_stat_bin)
+					 segment_names,taste_num_deliv_z,taste_select_epoch,
+					 use_full,bayes_dir_all_z,max_decode,max_hz_pop,seg_stat_bin)
 	
 	
 #%%
@@ -257,46 +228,28 @@ if __name__ == '__main__':
 	if os.path.isdir(bayes_dir_select_z) == False:
 		os.mkdir(bayes_dir_select_z)
 	
-	#Get FR Distributions
-	full_taste_fr_dist_z, tastant_fr_dist_z, tastant_fr_dist_pop_z, taste_num_deliv_z, \
-		max_hz, max_hz_pop, max_hz_full, min_hz, min_hz_pop, min_hz_full = df.taste_fr_dist_zscore(num_neur,num_cp,tastant_spike_times, 
-															segment_spike_times,segment_names,segment_times, 
-																taste_cp_raster_inds,pop_taste_cp_raster_inds, 
-																	start_dig_in_times, pre_taste_dt, post_taste_dt, bin_dt)
-	
-	#Assumes the parameters are the same from all neurons above
-	if use_full == 1:
-		#Decode by segment for a sliding post-taste bin size first
-		#___Decode using full taste response___
-		df.decode_full_zscore(full_taste_fr_dist_z,segment_spike_times,post_taste_dt,
-				   skip_dt,dig_in_names,segment_times,segment_names,bin_dt,
-				   start_dig_in_times,taste_num_deliv,taste_select_neur_bin,max_hz_full,min_hz_full,bayes_dir_select_z)
-	
-	
-	#___Phase 2: Decode using epoch-specific responses___
-	df.decode_epochs_zscore(tastant_fr_dist_z,segment_spike_times,post_taste_dt,
+	df.decode_epochs_zscore(tastant_fr_dist_pop_z,segment_spike_times,post_taste_dt,
 					   skip_dt,e_skip_dt,e_len_dt,dig_in_names,segment_times,bin_dt,
-					   segment_names,start_dig_in_times,taste_num_deliv,
+					   segment_names,start_dig_in_times,taste_num_deliv_z,
 					   taste_select_neur_epoch_bin,use_full,max_hz_pop,min_hz_pop,bayes_dir_select_z)
 	
 	#___Plot Results___
-	
-	df.plot_decoded(tastant_fr_dist,num_tastes,num_neur,num_cp,segment_spike_times,tastant_spike_times,
+	df.plot_decoded(tastant_fr_dist_pop_z,num_tastes,num_neur,num_cp,segment_spike_times,tastant_spike_times,
 					     start_dig_in_times,end_dig_in_times,post_taste_dt,pop_taste_cp_raster_inds,
 						  e_skip_dt,e_len_dt,dig_in_names,segment_times,
-						   segment_names,taste_num_deliv,taste_select_epoch,
+						   segment_names,taste_num_deliv_z,taste_select_epoch,
 						    use_full,bayes_dir_select_z,max_decode,max_hz_pop,seg_stat_bin,neuron_count_thresh)
 	
-	df.plot_decoded_func_p(tastant_fr_dist,num_tastes,num_neur,num_cp,segment_spike_times,tastant_spike_times,
+	df.plot_decoded_func_p(tastant_fr_dist_pop_z,num_tastes,num_neur,num_cp,segment_spike_times,tastant_spike_times,
 					 start_dig_in_times,end_dig_in_times,post_taste_dt,pop_taste_cp_raster_inds,
 					 e_skip_dt,e_len_dt,dig_in_names,segment_times,
-					 segment_names,taste_num_deliv,taste_select_epoch,
-					 use_full,bayes_dir_select_z,max_decode,max_hz,seg_stat_bin)
+					 segment_names,taste_num_deliv_z,taste_select_epoch,
+					 use_full,bayes_dir_select_z,max_decode,max_hz_pop,seg_stat_bin)
 	
-	df.plot_decoded_func_n(tastant_fr_dist,num_tastes,num_neur,num_cp,segment_spike_times,tastant_spike_times,
+	df.plot_decoded_func_n(tastant_fr_dist_pop_z,num_tastes,num_neur,num_cp,segment_spike_times,tastant_spike_times,
 					 start_dig_in_times,end_dig_in_times,post_taste_dt,pop_taste_cp_raster_inds,
 					 e_skip_dt,e_len_dt,dig_in_names,segment_times,
-					 segment_names,taste_num_deliv,taste_select_epoch,
-					 use_full,bayes_dir_select_z,max_decode,max_hz,seg_stat_bin)
+					 segment_names,taste_num_deliv_z,taste_select_epoch,
+					 use_full,bayes_dir_select_z,max_decode,max_hz_pop,seg_stat_bin)
 	
 	

--- a/bayes_replay_dependent_decoding.py
+++ b/bayes_replay_dependent_decoding.py
@@ -116,7 +116,6 @@ if __name__ == '__main__':
 					   taste_select_epoch,use_full,max_hz_pop,bayes_dir_all,
 					   neuron_count_thresh,trial_start_frac)
 	
-	
 	#___Plot Results___
 	df.plot_decoded(tastant_fr_dist_pop,num_tastes,num_neur,num_cp,segment_spike_times,tastant_spike_times,
 					 start_dig_in_times,end_dig_in_times,post_taste_dt,pop_taste_cp_raster_inds,

--- a/bayes_replay_dependent_decoding.py
+++ b/bayes_replay_dependent_decoding.py
@@ -76,6 +76,7 @@ if __name__ == '__main__':
 	neuron_count_thresh = 1/3 #Fraction of total population that must be active to consider a decoding event
 	max_decode = 50 #number of example decodes to plot
 	seg_stat_bin = 60*1000 #ms to bin segment for decoding counts in bins
+	trial_start_frac = 0 #Fractional start of trials to use in decoding
 	
 	#Z-scoring settings
 	bin_time = 0.1 #Seconds to skip forward in calculating firing rates
@@ -87,14 +88,14 @@ if __name__ == '__main__':
 														  num_cp,tastant_spike_times,
 														  pop_taste_cp_raster_inds,
 														  start_dig_in_times, pre_taste_dt,
-														  post_taste_dt)
+														  post_taste_dt, trial_start_frac)
 	
 	tastant_fr_dist_z_pop, taste_num_deliv, max_hz_z_pop, min_hz_z_pop = ddf.taste_fr_dist_zscore(num_neur,
 														  num_cp,tastant_spike_times,
 														  segment_spike_times,segment_names,
 														  segment_times,pop_taste_cp_raster_inds,
 														  start_dig_in_times, pre_taste_dt,
-														  post_taste_dt, bin_dt)
+														  post_taste_dt, bin_dt, trial_start_frac)
 	
 	#%%
 	
@@ -112,7 +113,8 @@ if __name__ == '__main__':
 	ddf.decode_epochs(tastant_fr_dist_pop,segment_spike_times,post_taste_dt,
 					   skip_dt,e_skip_dt,e_len_dt,dig_in_names,segment_times,
 					   segment_names,start_dig_in_times,taste_num_deliv,
-					   taste_select_epoch,use_full,max_hz_pop,bayes_dir_all,neuron_count_thresh)
+					   taste_select_epoch,use_full,max_hz_pop,bayes_dir_all,
+					   neuron_count_thresh,trial_start_frac)
 	
 	
 	#___Plot Results___
@@ -120,7 +122,8 @@ if __name__ == '__main__':
 					 start_dig_in_times,end_dig_in_times,post_taste_dt,pop_taste_cp_raster_inds,
 					 e_skip_dt,e_len_dt,dig_in_names,segment_times,
 					 segment_names,taste_num_deliv,taste_select_epoch,
-					 use_full,bayes_dir_all,max_decode,max_hz_pop,seg_stat_bin,neuron_count_thresh)
+					 use_full,bayes_dir_all,max_decode,max_hz_pop,seg_stat_bin,
+					 neuron_count_thresh,trial_start_frac)
 	
 	df.plot_decoded_func_p(tastant_fr_dist_pop,num_tastes,num_neur,num_cp,segment_spike_times,tastant_spike_times,
 					 start_dig_in_times,end_dig_in_times,post_taste_dt,pop_taste_cp_raster_inds,
@@ -154,13 +157,15 @@ if __name__ == '__main__':
 	ddf.decode_epochs(tastant_fr_dist_pop,segment_spike_times,post_taste_dt,
 					   skip_dt,e_skip_dt,e_len_dt,dig_in_names,segment_times,
 					   segment_names,start_dig_in_times,taste_num_deliv,
-					   taste_select_neur_epoch_bin,use_full,max_hz_pop,bayes_dir_select,neuron_count_thresh)
+					   taste_select_neur_epoch_bin,use_full,max_hz_pop,bayes_dir_select,
+					   neuron_count_thresh,trial_start_frac)
 					
 	df.plot_decoded(tastant_fr_dist_pop,num_tastes,num_neur,num_cp,segment_spike_times,tastant_spike_times,
 					     start_dig_in_times,end_dig_in_times,post_taste_dt,pop_taste_cp_raster_inds,
 						  e_skip_dt,e_len_dt,dig_in_names,segment_times,
 						   segment_names,taste_num_deliv,taste_select_neur_epoch_bin,
-						    use_full,bayes_dir_select,max_decode,max_hz_pop,seg_stat_bin,neuron_count_thresh)
+						    use_full,bayes_dir_select,max_decode,max_hz_pop,seg_stat_bin,
+							neuron_count_thresh,trial_start_frac)
 
 	df.plot_decoded_func_p(tastant_fr_dist_pop,num_tastes,num_neur,num_cp,segment_spike_times,tastant_spike_times,
 					 start_dig_in_times,end_dig_in_times,post_taste_dt,pop_taste_cp_raster_inds,
@@ -190,13 +195,15 @@ if __name__ == '__main__':
 	ddf.decode_epochs_zscore(tastant_fr_dist_z_pop,segment_spike_times,post_taste_dt,
 					   skip_dt,e_skip_dt,e_len_dt,dig_in_names,segment_times,bin_dt,
 					   segment_names,start_dig_in_times,taste_num_deliv,
-					   taste_select_epoch,use_full,max_hz_z_pop,bayes_dir_all_z,neuron_count_thresh)
+					   taste_select_epoch,use_full,max_hz_z_pop,bayes_dir_all_z,
+					   neuron_count_thresh,trial_start_frac)
 	
 	df.plot_decoded(tastant_fr_dist_z_pop,num_tastes,num_neur,num_cp,segment_spike_times,tastant_spike_times,
 					 start_dig_in_times,end_dig_in_times,post_taste_dt,pop_taste_cp_raster_inds,
 					 e_skip_dt,e_len_dt,dig_in_names,segment_times,
 					 segment_names,taste_num_deliv,taste_select_epoch,
-					 use_full,bayes_dir_all_z,max_decode,max_hz_z_pop,seg_stat_bin,neuron_count_thresh)
+					 use_full,bayes_dir_all_z,max_decode,max_hz_z_pop,seg_stat_bin,
+					 neuron_count_thresh,trial_start_frac)
 
 	df.plot_decoded_func_p(tastant_fr_dist_z_pop,num_tastes,num_neur,num_cp,segment_spike_times,tastant_spike_times,
 				 start_dig_in_times,end_dig_in_times,post_taste_dt,pop_taste_cp_raster_inds,
@@ -230,13 +237,15 @@ if __name__ == '__main__':
 	ddf.decode_epochs_zscore(tastant_fr_dist_z_pop,segment_spike_times,post_taste_dt,
 					   skip_dt,e_skip_dt,e_len_dt,dig_in_names,segment_times,bin_dt,
 					   segment_names,start_dig_in_times,taste_num_deliv,
-					   taste_select_neur_epoch_bin,use_full,max_hz_z_pop,bayes_dir_select_z,neuron_count_thresh)
+					   taste_select_neur_epoch_bin,use_full,max_hz_z_pop,
+					   bayes_dir_select_z,neuron_count_thresh,trial_start_frac)
 	
 	df.plot_decoded(tastant_fr_dist_z_pop,num_tastes,num_neur,num_cp,segment_spike_times,tastant_spike_times,
 					 start_dig_in_times,end_dig_in_times,post_taste_dt,pop_taste_cp_raster_inds,
 					 e_skip_dt,e_len_dt,dig_in_names,segment_times,
 					 segment_names,taste_num_deliv,taste_select_neur_epoch_bin,
-					 use_full,bayes_dir_select_z,max_decode,max_hz_z_pop,seg_stat_bin,neuron_count_thresh)
+					 use_full,bayes_dir_select_z,max_decode,max_hz_z_pop,seg_stat_bin,
+					 neuron_count_thresh,trial_start_frac)
 
 	df.plot_decoded_func_p(tastant_fr_dist_z_pop,num_tastes,num_neur,num_cp,segment_spike_times,tastant_spike_times,
 				 start_dig_in_times,end_dig_in_times,post_taste_dt,pop_taste_cp_raster_inds,

--- a/bayes_replay_dependent_decoding.py
+++ b/bayes_replay_dependent_decoding.py
@@ -51,9 +51,9 @@ if __name__ == '__main__':
 
 	#Raster Poisson Bayes Changepoint Calcs Indiv Neurons
 	data_group_name = 'changepoint_data'
-	taste_cp_raster_inds = af.pull_data_from_hdf5(sorted_dir,data_group_name,'taste_cp_raster_inds')
+	#taste_cp_raster_inds = af.pull_data_from_hdf5(sorted_dir,data_group_name,'taste_cp_raster_inds')
 	pop_taste_cp_raster_inds = af.pull_data_from_hdf5(sorted_dir,data_group_name,'pop_taste_cp_raster_inds')
-	num_cp = np.shape(taste_cp_raster_inds[0])[-1] - 1
+	num_cp = np.shape(pop_taste_cp_raster_inds[0])[-1] - 1
 	
 	bayes_dir = fig_save_dir + 'Bayes_Dependent_Decoding/'
 	if os.path.isdir(bayes_dir) == False:
@@ -81,11 +81,20 @@ if __name__ == '__main__':
 	bin_time = 0.1 #Seconds to skip forward in calculating firing rates
 	bin_dt = np.ceil(bin_time*1000).astype('int')
 	
-	tastant_fr_dist, full_taste_fr_dist, taste_num_deliv, max_hz, max_hz_full = ddf.taste_fr_dist(num_neur,
+	#%% Grab fr distributions
+	
+	tastant_fr_dist_pop, taste_num_deliv, max_hz_pop = ddf.taste_fr_dist(num_neur,
 														  num_cp,tastant_spike_times,
 														  pop_taste_cp_raster_inds,
 														  start_dig_in_times, pre_taste_dt,
 														  post_taste_dt)
+	
+	tastant_fr_dist_z_pop, taste_num_deliv, max_hz_z_pop, min_hz_z_pop = ddf.taste_fr_dist_zscore(num_neur,
+														  num_cp,tastant_spike_times,
+														  segment_spike_times,segment_names,
+														  segment_times,pop_taste_cp_raster_inds,
+														  start_dig_in_times, pre_taste_dt,
+														  post_taste_dt, bin_dt)
 	
 	#%%
 	
@@ -100,30 +109,30 @@ if __name__ == '__main__':
 	taste_select_epoch = np.ones((num_cp,num_neur)) #stand in to use full population
 	
 	
-	ddf.decode_epochs(tastant_fr_dist,segment_spike_times,post_taste_dt,
+	ddf.decode_epochs(tastant_fr_dist_pop,segment_spike_times,post_taste_dt,
 					   skip_dt,e_skip_dt,e_len_dt,dig_in_names,segment_times,
 					   segment_names,start_dig_in_times,taste_num_deliv,
-					   taste_select_epoch,use_full,max_hz,bayes_dir_all,neuron_count_thresh)
+					   taste_select_epoch,use_full,max_hz_pop,bayes_dir_all,neuron_count_thresh)
 	
 	
 	#___Plot Results___
-	df.plot_decoded(tastant_fr_dist,num_tastes,num_neur,num_cp,segment_spike_times,tastant_spike_times,
+	df.plot_decoded(tastant_fr_dist_pop,num_tastes,num_neur,num_cp,segment_spike_times,tastant_spike_times,
 					 start_dig_in_times,end_dig_in_times,post_taste_dt,pop_taste_cp_raster_inds,
 					 e_skip_dt,e_len_dt,dig_in_names,segment_times,
 					 segment_names,taste_num_deliv,taste_select_epoch,
-					 use_full,bayes_dir_all,max_decode,max_hz,seg_stat_bin,neuron_count_thresh)
+					 use_full,bayes_dir_all,max_decode,max_hz_pop,seg_stat_bin,neuron_count_thresh)
 	
-	df.plot_decoded_func_p(tastant_fr_dist,num_tastes,num_neur,num_cp,segment_spike_times,tastant_spike_times,
+	df.plot_decoded_func_p(tastant_fr_dist_pop,num_tastes,num_neur,num_cp,segment_spike_times,tastant_spike_times,
 					 start_dig_in_times,end_dig_in_times,post_taste_dt,pop_taste_cp_raster_inds,
 					 e_skip_dt,e_len_dt,dig_in_names,segment_times,
 					 segment_names,taste_num_deliv,taste_select_epoch,
-					 use_full,bayes_dir_all,max_decode,max_hz,seg_stat_bin)
+					 use_full,bayes_dir_all,max_decode,max_hz_pop,seg_stat_bin)
 	
-	df.plot_decoded_func_n(tastant_fr_dist,num_tastes,num_neur,num_cp,segment_spike_times,tastant_spike_times,
+	df.plot_decoded_func_n(tastant_fr_dist_pop,num_tastes,num_neur,num_cp,segment_spike_times,tastant_spike_times,
 					 start_dig_in_times,end_dig_in_times,post_taste_dt,pop_taste_cp_raster_inds,
 					 e_skip_dt,e_len_dt,dig_in_names,segment_times,
 					 segment_names,taste_num_deliv,taste_select_epoch,
-					 use_full,bayes_dir_all,max_decode,max_hz,seg_stat_bin)
+					 use_full,bayes_dir_all,max_decode,max_hz_pop,seg_stat_bin)
 
 #%%
 
@@ -142,28 +151,28 @@ if __name__ == '__main__':
 	if os.path.isdir(bayes_dir_select) == False:
 		os.mkdir(bayes_dir_select)
 	
-	ddf.decode_epochs(tastant_fr_dist,segment_spike_times,post_taste_dt,
+	ddf.decode_epochs(tastant_fr_dist_pop,segment_spike_times,post_taste_dt,
 					   skip_dt,e_skip_dt,e_len_dt,dig_in_names,segment_times,
 					   segment_names,start_dig_in_times,taste_num_deliv,
-					   taste_select_neur_epoch_bin,use_full,max_hz,bayes_dir_select,neuron_count_thresh)
+					   taste_select_neur_epoch_bin,use_full,max_hz_pop,bayes_dir_select,neuron_count_thresh)
 					
-	df.plot_decoded(tastant_fr_dist,num_tastes,num_neur,num_cp,segment_spike_times,tastant_spike_times,
+	df.plot_decoded(tastant_fr_dist_pop,num_tastes,num_neur,num_cp,segment_spike_times,tastant_spike_times,
 					     start_dig_in_times,end_dig_in_times,post_taste_dt,pop_taste_cp_raster_inds,
 						  e_skip_dt,e_len_dt,dig_in_names,segment_times,
 						   segment_names,taste_num_deliv,taste_select_neur_epoch_bin,
-						    use_full,bayes_dir_select,max_decode,max_hz,seg_stat_bin,neuron_count_thresh)
+						    use_full,bayes_dir_select,max_decode,max_hz_pop,seg_stat_bin,neuron_count_thresh)
 
-	df.plot_decoded_func_p(tastant_fr_dist,num_tastes,num_neur,num_cp,segment_spike_times,tastant_spike_times,
+	df.plot_decoded_func_p(tastant_fr_dist_pop,num_tastes,num_neur,num_cp,segment_spike_times,tastant_spike_times,
 					 start_dig_in_times,end_dig_in_times,post_taste_dt,pop_taste_cp_raster_inds,
 					 e_skip_dt,e_len_dt,dig_in_names,segment_times,
 					 segment_names,taste_num_deliv,taste_select_epoch,
-					 use_full,bayes_dir_select,max_decode,max_hz,seg_stat_bin)
+					 use_full,bayes_dir_select,max_decode,max_hz_pop,seg_stat_bin)
 	
-	df.plot_decoded_func_n(tastant_fr_dist,num_tastes,num_neur,num_cp,segment_spike_times,tastant_spike_times,
+	df.plot_decoded_func_n(tastant_fr_dist_pop,num_tastes,num_neur,num_cp,segment_spike_times,tastant_spike_times,
 					 start_dig_in_times,end_dig_in_times,post_taste_dt,pop_taste_cp_raster_inds,
 					 e_skip_dt,e_len_dt,dig_in_names,segment_times,
 					 segment_names,taste_num_deliv,taste_select_epoch,
-					 use_full,bayes_dir_select,max_decode,max_hz,seg_stat_bin)
+					 use_full,bayes_dir_select,max_decode,max_hz_pop,seg_stat_bin)
 
 
 #%%
@@ -177,36 +186,29 @@ if __name__ == '__main__':
 	taste_select = np.ones(num_neur) #stand in to use full population
 	taste_select_epoch = np.ones((num_cp,num_neur)) #stand in to use full population
 	
-	full_taste_fr_dist_z, tastant_fr_dist_z, taste_num_deliv, max_hz, \
-		max_hz_full, min_hz, min_hz_full = ddf.taste_fr_dist_zscore(num_neur,
-														  num_cp,tastant_spike_times,
-														  segment_spike_times,segment_names,
-														  segment_times,pop_taste_cp_raster_inds,
-														  start_dig_in_times, pre_taste_dt,
-														  post_taste_dt, bin_dt)
 	
-	ddf.decode_epochs_zscore(tastant_fr_dist_z,segment_spike_times,post_taste_dt,
+	ddf.decode_epochs_zscore(tastant_fr_dist_z_pop,segment_spike_times,post_taste_dt,
 					   skip_dt,e_skip_dt,e_len_dt,dig_in_names,segment_times,bin_dt,
 					   segment_names,start_dig_in_times,taste_num_deliv,
-					   taste_select_epoch,use_full,max_hz,bayes_dir_all_z,neuron_count_thresh)
+					   taste_select_epoch,use_full,max_hz_z_pop,bayes_dir_all_z,neuron_count_thresh)
 	
-	df.plot_decoded(tastant_fr_dist,num_tastes,num_neur,num_cp,segment_spike_times,tastant_spike_times,
+	df.plot_decoded(tastant_fr_dist_z_pop,num_tastes,num_neur,num_cp,segment_spike_times,tastant_spike_times,
 					 start_dig_in_times,end_dig_in_times,post_taste_dt,pop_taste_cp_raster_inds,
 					 e_skip_dt,e_len_dt,dig_in_names,segment_times,
 					 segment_names,taste_num_deliv,taste_select_epoch,
-					 use_full,bayes_dir_all_z,max_decode,max_hz,seg_stat_bin,neuron_count_thresh)
+					 use_full,bayes_dir_all_z,max_decode,max_hz_z_pop,seg_stat_bin,neuron_count_thresh)
 
-	df.plot_decoded_func_p(tastant_fr_dist,num_tastes,num_neur,num_cp,segment_spike_times,tastant_spike_times,
+	df.plot_decoded_func_p(tastant_fr_dist_z_pop,num_tastes,num_neur,num_cp,segment_spike_times,tastant_spike_times,
 				 start_dig_in_times,end_dig_in_times,post_taste_dt,pop_taste_cp_raster_inds,
 				 e_skip_dt,e_len_dt,dig_in_names,segment_times,
 				 segment_names,taste_num_deliv,taste_select_epoch,
-				 use_full,bayes_dir_all_z,max_decode,max_hz,seg_stat_bin)
+				 use_full,bayes_dir_all_z,max_decode,max_hz_z_pop,seg_stat_bin)
 	
-	df.plot_decoded_func_n(tastant_fr_dist,num_tastes,num_neur,num_cp,segment_spike_times,tastant_spike_times,
+	df.plot_decoded_func_n(tastant_fr_dist_z_pop,num_tastes,num_neur,num_cp,segment_spike_times,tastant_spike_times,
 					 start_dig_in_times,end_dig_in_times,post_taste_dt,pop_taste_cp_raster_inds,
 					 e_skip_dt,e_len_dt,dig_in_names,segment_times,
 					 segment_names,taste_num_deliv,taste_select_epoch,
-					 use_full,bayes_dir_all_z,max_decode,max_hz,seg_stat_bin)
+					 use_full,bayes_dir_all_z,max_decode,max_hz_z_pop,seg_stat_bin)
 
 	
 #%%
@@ -225,35 +227,27 @@ if __name__ == '__main__':
 	if os.path.isdir(bayes_dir_select_z) == False:
 		os.mkdir(bayes_dir_select_z)
 	
-	full_taste_fr_dist_z, tastant_fr_dist_z, taste_num_deliv, max_hz, \
-		max_hz_full, min_hz, min_hz_full = ddf.taste_fr_dist_zscore(num_neur,
-														  num_cp,tastant_spike_times,
-														  segment_spike_times,segment_names,
-														  segment_times,pop_taste_cp_raster_inds,
-														  start_dig_in_times, pre_taste_dt,
-														  post_taste_dt, bin_dt)
-	
-	ddf.decode_epochs_zscore(tastant_fr_dist_z,segment_spike_times,post_taste_dt,
+	ddf.decode_epochs_zscore(tastant_fr_dist_z_pop,segment_spike_times,post_taste_dt,
 					   skip_dt,e_skip_dt,e_len_dt,dig_in_names,segment_times,bin_dt,
 					   segment_names,start_dig_in_times,taste_num_deliv,
-					   taste_select_neur_epoch_bin,use_full,max_hz,bayes_dir_select_z,neuron_count_thresh)
+					   taste_select_neur_epoch_bin,use_full,max_hz_z_pop,bayes_dir_select_z,neuron_count_thresh)
 	
-	df.plot_decoded(tastant_fr_dist,num_tastes,num_neur,num_cp,segment_spike_times,tastant_spike_times,
+	df.plot_decoded(tastant_fr_dist_z_pop,num_tastes,num_neur,num_cp,segment_spike_times,tastant_spike_times,
 					 start_dig_in_times,end_dig_in_times,post_taste_dt,pop_taste_cp_raster_inds,
 					 e_skip_dt,e_len_dt,dig_in_names,segment_times,
 					 segment_names,taste_num_deliv,taste_select_neur_epoch_bin,
-					 use_full,bayes_dir_select_z,max_decode,max_hz,seg_stat_bin,neuron_count_thresh)
+					 use_full,bayes_dir_select_z,max_decode,max_hz_z_pop,seg_stat_bin,neuron_count_thresh)
 
-	df.plot_decoded_func_p(tastant_fr_dist,num_tastes,num_neur,num_cp,segment_spike_times,tastant_spike_times,
+	df.plot_decoded_func_p(tastant_fr_dist_z_pop,num_tastes,num_neur,num_cp,segment_spike_times,tastant_spike_times,
 				 start_dig_in_times,end_dig_in_times,post_taste_dt,pop_taste_cp_raster_inds,
 				 e_skip_dt,e_len_dt,dig_in_names,segment_times,
 				 segment_names,taste_num_deliv,taste_select_epoch,
-				 use_full,bayes_dir_select_z,max_decode,max_hz,seg_stat_bin)
+				 use_full,bayes_dir_select_z,max_decode,max_hz_z_pop,seg_stat_bin)
 	
-	df.plot_decoded_func_n(tastant_fr_dist,num_tastes,num_neur,num_cp,segment_spike_times,tastant_spike_times,
+	df.plot_decoded_func_n(tastant_fr_dist_z_pop,num_tastes,num_neur,num_cp,segment_spike_times,tastant_spike_times,
 					 start_dig_in_times,end_dig_in_times,post_taste_dt,pop_taste_cp_raster_inds,
 					 e_skip_dt,e_len_dt,dig_in_names,segment_times,
 					 segment_names,taste_num_deliv,taste_select_epoch,
-					 use_full,bayes_dir_select_z,max_decode,max_hz,seg_stat_bin)
+					 use_full,bayes_dir_select_z,max_decode,max_hz_z_pop,seg_stat_bin)
 
 	

--- a/functions/decoding_funcs.py
+++ b/functions/decoding_funcs.py
@@ -324,101 +324,33 @@ def taste_fr_dist(num_neur,num_cp,tastant_spike_times,
 	
 	#Determine the spike fr distributions for each neuron for each taste
 	#print("\tPulling spike fr distributions by taste by neuron")
-	#____Baby decoder block____
-# 	full_taste_fr_dist = np.nan*np.ones((num_tastes,num_neur,max_num_deliv)) #Full taste response firing rate distribution
-# 	tastant_fr_dist = np.nan*np.ones((num_tastes,num_neur,max_num_deliv,num_cp)) #Individual neuron firing rate distributions by epoch
-# 	tastant_fr_dist_pop = np.nan*np.ones((num_tastes,num_neur,max_num_deliv,num_cp)) #Population firing rate distributions by epoch
-	#____
-	#Toddler decoder block____
-	full_taste_fr_dist = dict() #Full taste response firing rate distribution
-	tastant_fr_dist = dict() #Individual neuron firing rate distributions by epoch
 	tastant_fr_dist_pop = dict() #Population firing rate distributions by epoch
 	for t_i in range(num_tastes):
-		full_taste_fr_dist[t_i] = dict()
-		tastant_fr_dist[t_i] = dict()
 		tastant_fr_dist_pop[t_i] = dict()
 		for n_i in range(num_neur):
-			full_taste_fr_dist[t_i][n_i] = dict()
-			tastant_fr_dist[t_i][n_i] = dict()
 			tastant_fr_dist_pop[t_i][n_i] = dict()
 			for d_i in range(max_num_deliv):
-				full_taste_fr_dist[t_i][n_i][d_i] = dict()
-				tastant_fr_dist[t_i][n_i][d_i] = dict()
 				tastant_fr_dist_pop[t_i][n_i][d_i] = dict()
 				for cp_i in range(num_cp):
-					tastant_fr_dist[t_i][n_i][d_i][cp_i] = dict()
 					tastant_fr_dist_pop[t_i][n_i][d_i][cp_i] = dict()
 	#____
-	max_hz = 0
 	max_hz_pop = 0
-	max_hz_full = 0
 	for t_i in range(num_tastes):
 		num_deliv = taste_num_deliv[t_i]
-		taste_cp = taste_cp_raster_inds[t_i]
 		taste_cp_pop = pop_taste_cp_raster_inds[t_i]
 		for n_i in range(num_neur):
 			for d_i in range(num_deliv): #index for that taste
 				raster_times = tastant_spike_times[t_i][d_i][n_i]
 				start_taste_i = start_dig_in_times[t_i][d_i]
-				deliv_cp = taste_cp[d_i,n_i,:] - pre_taste_dt
 				deliv_cp_pop = taste_cp_pop[d_i,:] - pre_taste_dt
 				#Bin the average firing rates following taste delivery start
 				times_post_taste = (np.array(raster_times)[np.where((raster_times >= start_taste_i)*(raster_times < start_taste_i + post_taste_dt))[0]] - start_taste_i).astype('int')
 				bin_post_taste = np.zeros(post_taste_dt)
 				bin_post_taste[times_post_taste] += 1
-				deliv_binned_fr = []
-				deliv_binned_fr_pop = []
 				for cp_i in range(num_cp):
-					#individual neuron changepoints
-					start_epoch = int(deliv_cp[cp_i])
-					end_epoch = int(deliv_cp[cp_i+1])
-					#____Baby decoder block____
-# 					bst_hz = np.sum(bin_post_taste[start_epoch:end_epoch])/((end_epoch - start_epoch)*(1/1000))
-# 					if bst_hz > max_hz:
-# 						max_hz = bst_hz
-# 					deliv_binned_fr.extend([bst_hz])
-					#____
-					#____Toddler decoder block____
-					#TODO: add variable to change the bin size
-# 					bin_edges = np.arange(start_epoch,end_epoch,100).astype('int') #bin the epoch
-# 					if len(bin_edges) != 0:
-# 						if (bin_edges[-1] != end_epoch)*(end_epoch - bin_edges[-1] > 10):
-# 							bin_edges = np.concatenate((bin_edges,end_epoch*np.ones(1).astype('int')))
-# 						bst_hz = [np.sum(bin_post_taste[bin_edges[b_i]:bin_edges[b_i+1]])/((bin_edges[b_i+1] - bin_edges[b_i])*(1/1000)) for b_i in range(len(bin_edges)-1)]
-# 						tastant_fr_dist[t_i][n_i][d_i][cp_i] = bst_hz
-# 						if np.max(bst_hz) > max_hz:
-# 							max_hz = np.max(bst_hz)
-					#____
-					#____Teen decoder block____
-					#TODO: add variable to change the bin size
-					#Sweep across the interval continuously pulling distribution
-					bin_starts = np.arange(start_epoch,end_epoch-100).astype('int') #bin the epoch
-					if len(bin_starts) != 0:
-						bst_hz = [np.sum(bin_post_taste[bin_starts[b_i]:bin_starts[b_i]+100])/(100/1000) for b_i in range(len(bin_starts))]
-						tastant_fr_dist[t_i][n_i][d_i][cp_i] = bst_hz
-						if np.max(bst_hz) > max_hz:
-							max_hz = np.max(bst_hz)
-					#____
 					#population changepoints
 					start_epoch = int(deliv_cp_pop[cp_i])
 					end_epoch = int(deliv_cp_pop[cp_i+1])
-					#____Baby decoder block____
-# 					bst_hz = np.sum(bin_post_taste[start_epoch:end_epoch])/((end_epoch - start_epoch)*(1/1000))
-# 					if bst_hz > max_hz_pop:
-# 						max_hz_pop = bst_hz
-# 					deliv_binned_fr_pop.extend([bst_hz])
-					#____
-					#____Toddler decoder block____
-					#TODO: add variable to change the bin size
-# 					bin_edges = np.arange(start_epoch,end_epoch,100).astype('int') #bin the epoch
-# 					if len(bin_edges) != 0:
-# 						if (bin_edges[-1] != end_epoch)*(end_epoch - bin_edges[-1] > 10):
-# 							bin_edges = np.concatenate((bin_edges,end_epoch*np.ones(1).astype('int')))
-# 						bst_hz = [np.sum(bin_post_taste[bin_edges[b_i]:bin_edges[b_i+1]])/((bin_edges[b_i+1] - bin_edges[b_i])*(1/1000)) for b_i in range(len(bin_edges)-1)]
-# 						tastant_fr_dist_pop[t_i][n_i][d_i][cp_i] = bst_hz
-# 						if np.max(bst_hz) > max_hz_pop:
-# 							max_hz_pop = np.max(bst_hz)
- 					#____
 					#____Teen decoder block____
 					#TODO: add variable to change the bin size
 					#Sweep across the interval continuously pulling distribution
@@ -430,222 +362,13 @@ def taste_fr_dist(num_neur,num_cp,tastant_spike_times,
 							max_hz_pop = np.max(bst_hz)
 					#____
 				del cp_i, start_epoch, end_epoch, bst_hz
-				#____Baby decoder block____
-# 				full_taste_fr_dist[t_i,n_i,d_i] = np.sum(bin_post_taste)/(post_taste_dt*(1/1000))
-# 				tastant_fr_dist[t_i,n_i,d_i,:] = deliv_binned_fr
-# 				tastant_fr_dist_pop[t_i,n_i,d_i,:] = deliv_binned_fr_pop
-				#____
-				#____Toddler decoder block____
-# 				bin_edges = np.arange(0,post_taste_dt,100).astype('int') #bin the epoch
-# 				if len(bin_edges) != 0:
-# 					if (bin_edges[-1] != post_taste_dt)*(post_taste_dt - bin_edges[-1] > 10):
-# 						bin_edges = np.concatenate((bin_edges,post_taste_dt*np.ones(1).astype('int')))
-# 					bst_hz = [np.sum(bin_post_taste[bin_edges[b_i]:bin_edges[b_i+1]])/((bin_edges[b_i+1] - bin_edges[b_i])*(1/1000)) for b_i in range(len(bin_edges)-1)]
-# 					full_taste_fr_dist[t_i][n_i][d_i] = bst_hz
-# 					if np.max(bst_hz) > max_hz_full:
-# 						max_hz_full = np.max(bst_hz)
 				#___
-				#Teen decoder block____
-				bin_starts = np.arange(0,post_taste_dt-100).astype('int') #bin the epoch
-				if len(bin_starts) != 0:
-					bst_hz = [np.sum(bin_post_taste[bin_starts[b_i]:bin_starts[b_i]+100])/(100/1000) for b_i in range(len(bin_starts))]
-					full_taste_fr_dist[t_i][n_i][d_i] = bst_hz
-					if np.max(bst_hz) > max_hz_full:
-						max_hz_full = np.max(bst_hz)
-				#___
-	del t_i, num_deliv, taste_cp, n_i, d_i, raster_times, start_taste_i, deliv_cp, times_post_taste, bin_post_taste
+	del t_i, num_deliv, n_i, d_i, raster_times, start_taste_i, times_post_taste, bin_post_taste
 
-	return full_taste_fr_dist, tastant_fr_dist, tastant_fr_dist_pop, taste_num_deliv, max_hz, max_hz_pop, max_hz_full
+	return tastant_fr_dist_pop, max_hz_pop, taste_num_deliv
 	
-def decode_full(full_taste_fr_dist,segment_spike_times,post_taste_dt,
-				   skip_dt,dig_in_names,segment_times,segment_names,
-				   start_dig_in_times,taste_num_deliv,taste_select,save_dir):
-	"""Decode probability of full taste response from sliding bin spiking 
-	across segments"""
-	#Pull necessary variables
-	num_tastes, num_neur, num_deliv = np.shape(full_taste_fr_dist)
-	num_segments = len(segment_spike_times)
-	max_hz = np.max(full_taste_fr_dist[~np.isnan(full_taste_fr_dist)])
-	hist_bins = np.arange(stop=max_hz+1,step=0.25)
-	x_vals = hist_bins[:-1] + np.diff(hist_bins)/2
-	p_taste = taste_num_deliv/np.sum(taste_num_deliv)
-	half_bin = np.floor(post_taste_dt/2).astype('int')
-	
-	prev_run = np.zeros(2)
-	
-	#Get neurons to cycle through based on binary taste_select which is num_neur in length
-	taste_select_neur = np.where(taste_select == 1)[0]
-	
-	#Fit gamma distributions to fr of each neuron for each taste
-	try:
-		fit_tastant_neur = np.load(save_dir + 'fit_tastant_neur_full_taste.npy')
-		prev_run[0] = 1
-	except:
-		fit_tastant_neur = np.zeros((num_tastes,num_neur,len(x_vals)+1))
-		for t_i in range(num_tastes):
-			for n_i in taste_select_neur:
-				#____Baby decoder block____
-# 				full_data = (full_taste_fr_dist[t_i,n_i,:]).flatten()
-# 				full_data = full_data[~np.isnan(full_data)]
-				#____
-				#____Toddler decoder block____
-				full_data = np.array(list(full_taste_fr_dist[t_i][n_i].values()))
-				#____
-				num_points = len(full_data)
-				bin_centers = np.linspace(0,max_hz+1,np.max([8,np.ceil(num_points/5).astype('int')]))
-				bins_calc = [bin_centers[0] - np.mean(np.diff(bin_centers))]
-				bins_calc.extend(bin_centers + np.mean(np.diff(bin_centers)))
-				fit_data = np.histogram(full_data,density=True,bins=bins_calc)
-				new_fit = interpolate.interp1d(bin_centers,fit_data[0],kind='linear')
-				filtered_data = new_fit(hist_bins)
-				filtered_data = filtered_data/np.sum(filtered_data) #return to a probability density
-				fit_tastant_neur[t_i,n_i,:] = filtered_data
-			del n_i, full_data, num_points, bin_centers, bins_calc, fit_data, new_fit, filtered_data
-		np.save(save_dir + 'fit_tastant_neur_full_taste.npy',fit_tastant_neur)
-	
-	#Fit the joint distribution across tastes
-	#print("\tFitting joint distribution by neuron")
-	try:
-		joint_fit_neur = np.load(save_dir + 'joint_fit_neur_full_taste.npy')
-		prev_run[1] = 1
-	except:
-		joint_fit_neur = np.zeros((num_neur,len(x_vals)+1))
-		for n_i in taste_select_neur:
-			#____Baby decoder block____
-# 			all_taste_fr = (full_taste_fr_dist[:,n_i,:]).flatten()
-# 			all_taste_fr = all_taste_fr[~np.isnan(all_taste_fr)]
-			#____
-			#____Toddler decoder block____
-			all_taste_fr = np.array([list(full_taste_fr_dist[t_i][n_i].values()) for t_i in range(num_tastes)]).flatten()
-			#____
-			bin_centers = np.linspace(0,max_hz+1)
-			bins_calc = [bin_centers[0] - np.mean(np.diff(bin_centers))]
-			bins_calc.extend(bin_centers + np.mean(np.diff(bin_centers)))
-			fit_data = np.histogram(all_taste_fr,density=True,bins=bins_calc)
-			new_fit = interpolate.interp1d(bin_centers,fit_data[0])
-			filtered_data = new_fit(hist_bins)
-			filtered_data = filtered_data/np.sum(filtered_data) #return to a probability density
-			joint_fit_neur[n_i,:] = filtered_data
-		del n_i, all_taste_fr, bin_centers, bins_calc, fit_data, new_fit, filtered_data
-		np.save(save_dir + 'joint_fit_neur_full_taste.npy',joint_fit_neur)
-	
-	if np.sum(prev_run) < 2:
-		#Plot the taste distributions against each other
-		fig_t, ax_t = plt.subplots(nrows=num_neur,ncols=1,sharex=True,figsize=(5,num_neur))
-		for n_i in taste_select_neur: 
-			if n_i == 0:	
-				ax_t[n_i].plot((fit_tastant_neur[:,n_i,:]).T,label=np.array(dig_in_names))
-				ax_t[n_i].plot((joint_fit_neur[n_i,:]).T,label='Joint Dist')
-				ax_t[n_i].legend()
-			else:
-				ax_t[n_i].plot((fit_tastant_neur[:,n_i,:]).T)
-				ax_t[n_i].plot((joint_fit_neur[n_i,:]).T,label='Joint Dist')
-				ax_t[n_i].legend()
-		ax_t[num_neur-1].set_xlabel('Firing Rate (Hz)')
-		fig_t.supylabel('Probability')
-		fig_t.tight_layout()
-		fig_t.savefig(save_dir + 'full_taste_fr_dist_fits.png')
-		fig_t.savefig(save_dir + 'full_taste_fr_dist_fits.svg')
-		plt.close(fig_t)
-	
-	#Segment-by-segment use sliding bin with a skip
-	seg_decode_save_dir = save_dir + 'decode_prob_full_taste/'
-	if not os.path.isdir(seg_decode_save_dir):
-		os.mkdir(seg_decode_save_dir)
-	for s_i in range(num_segments):
-		try:
-			seg_decode_prob = np.load(seg_decode_save_dir + 'segment_' + str(s_i) + '.npy')
-			print("Segment " + str(s_i) + " Previously Decoded")
-		except:
-			print("Decoding Segment " + str(s_i))
-			seg_start = segment_times[s_i]
-			seg_end = segment_times[s_i+1]
-			time_bin_starts = np.arange(seg_start+post_taste_dt,seg_end-post_taste_dt,skip_dt)
-			num_times = len(time_bin_starts)
-			seg_decode_prob = np.zeros((num_tastes,num_times))
-			for tb_i,tb in enumerate(tqdm.tqdm(time_bin_starts)):
-				neur_decode_prob = np.nan*np.ones((num_tastes,num_neur))
-				for t_i in range(num_tastes):
-					for n_i in taste_select_neur:
-						neur_spike_fr = len(np.where((np.int64(tb-half_bin) <= segment_spike_times[s_i][n_i])*(np.int64(tb)+half_bin >= segment_spike_times[s_i][n_i]))[0])/(2*half_bin*(1/1000))
-						closest_x = np.argmin(np.abs(x_vals - neur_spike_fr))
-						p_fr_taste = fit_tastant_neur[t_i,n_i,closest_x]
-						p_fr = joint_fit_neur[n_i,closest_x]
-						if (p_fr > 0)*((p_fr_taste*p_taste[t_i])>0):
-							neur_decode_prob[t_i,n_i] = (p_fr_taste)/p_fr
-						else:
-							neur_decode_prob[t_i,n_i] = np.nan
-				joint_decode_prob = [np.prod(neur_decode_prob[t_i,~np.isnan(neur_decode_prob[t_i,:])])*p_taste[t_i] for t_i in range(num_tastes)]
-				seg_decode_prob[:,tb_i] = np.array(joint_decode_prob)
-			#Save decoding probabilities
-			np.save(seg_decode_save_dir + 'segment_' + str(s_i) + '.npy',seg_decode_prob)
-			#Create plots
-			seg_decode_pref = seg_decode_prob/np.sum(seg_decode_prob,0)
-			seg_decode_taste_ind = np.argmax(seg_decode_pref,0)
-			seg_decode_taste_bin = np.zeros(np.shape(seg_decode_pref))
-			for t_i in range(num_tastes):
-				seg_decode_taste_bin[t_i,np.where(seg_decode_taste_ind == t_i)[0]] = 1
-			#Line plot
-			f1 = plt.figure()
-			plt.plot(time_bin_starts/1000/60,seg_decode_pref.T)
-			for t_i in range(num_tastes):
-				plt.fill_between(time_bin_starts/1000/60,seg_decode_taste_bin[t_i,:],alpha=0.2)
-			plt.legend(dig_in_names)
-			plt.ylabel('Decoding Fraction')
-			plt.xlabel('Time (min)')
-			plt.title('Segment ' + str(s_i))
-			f1.savefig(seg_decode_save_dir + 'segment_' + str(s_i) + '.png')
-			f1.savefig(seg_decode_save_dir + 'segment_' + str(s_i) + '.svg')
-			plt.close(f1)
-			#Imshow
-			f2 = plt.figure()
-			plt.imshow(seg_decode_pref,aspect='auto',interpolation = 'none')
-			x_ticks = np.ceil(np.linspace(0,len(time_bin_starts)-1,10)).astype('int')
-			x_tick_labels = np.round(time_bin_starts[x_ticks]/1000/60,2)
-			plt.xticks(x_ticks,x_tick_labels)
-			y_ticks = np.arange(len(dig_in_names))
-			plt.yticks(y_ticks,dig_in_names)
-			plt.ylabel('Decoding Fraction')
-			plt.xlabel('Time (min)')
-			plt.title('Segment ' + str(s_i))
-			f2.savefig(seg_decode_save_dir + 'segment_' + str(s_i) + '_im.png')
-			f2.savefig(seg_decode_save_dir + 'segment_' + str(s_i) + '_im.svg')
-			plt.close(f2)
-			#Fraction of occurrences
-			f3 = plt.figure()
-			plt.pie(np.sum(seg_decode_taste_bin,1)/np.sum(seg_decode_taste_bin),labels=['water','saccharin','none'],autopct='%1.1f%%')
-			plt.title('Segment ' + str(s_i))
-			f3.savefig(seg_decode_save_dir + 'segment_' + str(s_i) + '_pie.png')
-			f3.savefig(seg_decode_save_dir + 'segment_' + str(s_i) + '_pie.svg')
-			plt.close(f3)
-			#If it's the taste interval, save separately decoding of each taste delivery
-			if segment_names[s_i].lower() == 'taste': #Assumes it's always called just "taste"
-				for t_i in range(num_tastes): #Do each taste and find if match
-					for st_i,st in enumerate(np.array(start_dig_in_times[t_i])):
-						#Plot the decoding to [-post_taste_dt,2*post_taste_dt] around delivery
-						f4 = plt.figure()
-						start_dec_t = max(st - post_taste_dt,seg_start)
-						closest_tbs = np.argmin(np.abs(time_bin_starts - start_dec_t))
-						end_dec_t = min(st + 2*post_taste_dt,seg_end)
-						closest_tbe = np.argmin(np.abs(time_bin_starts - end_dec_t))
-						closest_td = np.argmin(np.abs(time_bin_starts - st))
-						decode_tbs = np.arange(closest_tbs,closest_tbe)
-						decode_t = time_bin_starts[decode_tbs]
-						decode_t_labels = decode_t - st #in ms
-						decode_snip = seg_decode_pref[:,decode_tbs]
-						plt.plot(decode_t_labels,decode_snip.T)
-						for t_i_2 in range(num_tastes):
-							plt.fill_between(decode_t_labels,decode_snip[t_i_2,:],alpha=0.2)
-						plt.axvline(0)
-						plt.legend(dig_in_names)
-						plt.ylabel('Decoding Fraction')
-						plt.xlabel('Time From Delivery (ms)')
-						plt.title(dig_in_names[t_i] + ' delivery #' + str(st_i))
-						f4.savefig(seg_decode_save_dir + dig_in_names[t_i] + '_' + str(st_i) + '.png')
-						f4.savefig(seg_decode_save_dir + dig_in_names[t_i] + '_' + str(st_i) + '.svg')
-						plt.close(f4)
-			
-								
+
+
 def decode_epochs(tastant_fr_dist,segment_spike_times,post_taste_dt,
 				   skip_dt,e_skip_dt,e_len_dt,dig_in_names,segment_times,
 				   segment_names,start_dig_in_times,taste_num_deliv,
@@ -980,87 +703,34 @@ def taste_fr_dist_zscore(num_neur,num_cp,tastant_spike_times,segment_spike_times
 		
 	#Determine the spike fr distributions for each neuron for each taste
 	#print("\tPulling spike fr distributions by taste by neuron")
-	#____Baby decoder block____
-# 	full_taste_fr_dist = np.nan*np.ones((num_tastes,num_neur,max_num_deliv)) #Full taste response firing rate distribution
-# 	tastant_fr_dist = np.nan*np.ones((num_tastes,num_neur,max_num_deliv,num_cp)) #Individual neuron firing rate distributions by epoch
-# 	tastant_fr_dist_pop = np.nan*np.ones((num_tastes,num_neur,max_num_deliv,num_cp)) #Population firing rate distributions by epoch
-	#____
-	#Toddler decoder block____
-	full_taste_fr_dist = dict() #Full taste response firing rate distribution
-	tastant_fr_dist = dict() #Individual neuron firing rate distributions by epoch
 	tastant_fr_dist_pop = dict() #Population firing rate distributions by epoch
 	for t_i in range(num_tastes):
-		full_taste_fr_dist[t_i] = dict()
-		tastant_fr_dist[t_i] = dict()
 		tastant_fr_dist_pop[t_i] = dict()
 		for n_i in range(num_neur):
-			full_taste_fr_dist[t_i][n_i] = dict()
-			tastant_fr_dist[t_i][n_i] = dict()
 			tastant_fr_dist_pop[t_i][n_i] = dict()
 			for d_i in range(max_num_deliv):
-				full_taste_fr_dist[t_i][n_i][d_i] = dict()
-				tastant_fr_dist[t_i][n_i][d_i] = dict()
 				tastant_fr_dist_pop[t_i][n_i][d_i] = dict()
 				for cp_i in range(num_cp):
-					tastant_fr_dist[t_i][n_i][d_i][cp_i] = dict()
 					tastant_fr_dist_pop[t_i][n_i][d_i][cp_i] = dict()
 	#____
-	max_hz = 0
-	min_hz = 0
 	max_hz_pop = 0
 	min_hz_pop = 0
-	max_hz_full = 0
-	min_hz_full = 0
 	for t_i in range(num_tastes):
 		num_deliv = taste_num_deliv[t_i]
-		taste_cp = taste_cp_raster_inds[t_i]
 		taste_cp_pop = pop_taste_cp_raster_inds[t_i]
 		for n_i in range(num_neur):
 			for d_i in range(num_deliv): #index for that taste
 				raster_times = tastant_spike_times[t_i][d_i][n_i]
 				start_taste_i = start_dig_in_times[t_i][d_i]
-				deliv_cp = taste_cp[d_i,n_i,:] - pre_taste_dt
 				deliv_cp_pop = taste_cp_pop[d_i,:] - pre_taste_dt
 				#Bin the average firing rates following taste delivery start
 				times_post_taste = (np.array(raster_times)[np.where((raster_times >= start_taste_i)*(raster_times < start_taste_i + post_taste_dt))[0]] - start_taste_i).astype('int')
 				bin_post_taste = np.zeros(post_taste_dt)
 				bin_post_taste[times_post_taste] += 1
-# 				deliv_binned_fr = []
-# 				deliv_binned_fr_pop = []
 				for cp_i in range(num_cp):
-					#individual neuron changepoints
-					start_epoch = int(deliv_cp[cp_i])
-					end_epoch = int(deliv_cp[cp_i+1])
-					#____Baby decoder block____
-# 					bst_hz = ((np.sum(bin_post_taste[start_epoch:end_epoch])/((end_epoch - start_epoch)*(1/1000))) - mean_fr[n_i])/std_fr[n_i]
-# 					if bst_hz > max_hz:
-# 						max_hz = bst_hz
-# 					deliv_binned_fr.extend([bst_hz])
-					#____
-					#____Toddler decoder block____
-					#TODO: add variable to change the bin size
-					bin_edges = np.arange(start_epoch,end_epoch,100).astype('int') #bin the epoch
-					if len(bin_edges) != 0:
-						if bin_edges[-1] != end_epoch:
-							bin_edges = np.concatenate((bin_edges,end_epoch*np.ones(1).astype('int')))
-						bst_hz = [np.sum(bin_post_taste[bin_edges[b_i]:bin_edges[b_i+1]])/((bin_edges[b_i+1] - bin_edges[b_i])*(1/1000)) for b_i in range(len(bin_edges)-1)]
-						bst_hz_z = (np.array(bst_hz) - mean_fr[n_i])/std_fr[n_i]
-						tastant_fr_dist[t_i][n_i][d_i][cp_i] = bst_hz_z
-						if np.max(bst_hz_z) > max_hz:
-							max_hz = np.max(bst_hz_z)
-						if np.min(bst_hz_z) < min_hz:
-							min_hz = np.min(bst_hz_z)
-					#____
 					#population changepoints
 					start_epoch = int(deliv_cp_pop[cp_i])
 					end_epoch = int(deliv_cp_pop[cp_i+1])
-					#____Baby decoder block____
-# 					bst_hz = ((np.sum(bin_post_taste[start_epoch:end_epoch])/((end_epoch - start_epoch)*(1/1000))) - mean_fr[n_i])/std_fr[n_i]
-# 					if bst_hz > max_hz_pop:
-# 						max_hz_pop = bst_hz
-# 					deliv_binned_fr_pop.extend([bst_hz])
-					#____
-					#____Toddler decoder block____
 					#TODO: add variable to change the bin size
 					bin_edges = np.arange(start_epoch,end_epoch,100).astype('int') #bin the epoch
 					if len(bin_edges) != 0:
@@ -1075,241 +745,10 @@ def taste_fr_dist_zscore(num_neur,num_cp,tastant_spike_times,segment_spike_times
 							min_hz_pop = np.min(bst_hz_z)
 					#____
 				del cp_i, start_epoch, end_epoch, bst_hz, bst_hz_z
-				#____Baby decoder block____
-# 				full_taste_fr_dist[t_i,n_i,d_i] = ((np.sum(bin_post_taste)/(post_taste_dt*(1/1000))) - mean_fr[n_i])/std_fr[n_i]
-# 				tastant_fr_dist[t_i,n_i,d_i,:] = deliv_binned_fr
-# 				tastant_fr_dist_pop[t_i,n_i,d_i,:] = deliv_binned_fr_pop
-				#____
-				#____Toddler decoder block____
-				bin_edges = np.arange(0,post_taste_dt,100).astype('int') #bin the epoch
-				if len(bin_edges) != 0:
-					if bin_edges[-1] != post_taste_dt:
-						bin_edges = np.concatenate((bin_edges,post_taste_dt*np.ones(1).astype('int')))
-					bst_hz = [np.sum(bin_post_taste[bin_edges[b_i]:bin_edges[b_i+1]])/((bin_edges[b_i+1] - bin_edges[b_i])*(1/1000)) for b_i in range(len(bin_edges)-1)]
-					bst_hz_z = (np.array(bst_hz) - mean_fr[n_i])/std_fr[n_i]
-					full_taste_fr_dist[t_i][n_i][d_i] = bst_hz_z
-					if np.max(bst_hz_z) > max_hz_full:
-						max_hz_full = np.max(bst_hz_z)
-					if np.min(bst_hz_z) < min_hz_full:
-						min_hz_full = np.max(bst_hz_z)
-				#___
-	del t_i, num_deliv, taste_cp, n_i, d_i, raster_times, start_taste_i, deliv_cp, times_post_taste, bin_post_taste
+				
+	del t_i, num_deliv, n_i, d_i, raster_times, start_taste_i, times_post_taste, bin_post_taste
 
-	return full_taste_fr_dist, tastant_fr_dist, tastant_fr_dist_pop, \
-		taste_num_deliv, max_hz, max_hz_pop, max_hz_full, min_hz, min_hz_pop, min_hz_full
-
-
-def decode_full_zscore(full_taste_fr_dist_z,segment_spike_times,post_taste_dt,
-				   skip_dt,dig_in_names,segment_times,segment_names,bin_dt,
-				   start_dig_in_times,taste_num_deliv,taste_select,max_hz,min_hz,save_dir):
-	"""Decode probability of full taste response from sliding bin spiking 
-	across segments"""
-	#Pull necessary variables
-	num_tastes, num_neur, num_deliv = np.shape(full_taste_fr_dist_z)
-	num_segments = len(segment_spike_times)
-	hist_bins = np.arange(min_hz,max_hz+1,0.25)
-	x_vals = hist_bins[:-1] + np.diff(hist_bins)/2
-	p_taste = taste_num_deliv/np.sum(taste_num_deliv)
-	half_bin = np.floor(post_taste_dt/2).astype('int')
-	half_bin_z = np.floor(bin_dt/2).astype('int')
-	
-	prev_run = np.zeros(2)
-	
-	#Get neurons to cycle through based on binary taste_select which is num_neur in length
-	taste_select_neur = np.where(taste_select == 1)[0]
-	
-	#Fit gamma distributions to fr of each neuron for each taste
-	try:
-		fit_tastant_neur = np.load(save_dir + 'fit_tastant_neur_full_taste_z.npy')
-		prev_run[0] = 1
-	except:
-		fit_tastant_neur = np.zeros((num_tastes,num_neur,len(x_vals)+1))
-		for t_i in range(num_tastes):
-			for n_i in taste_select_neur:
-				full_data = (full_taste_fr_dist_z[t_i,n_i,:]).flatten()
-				full_data = full_data[~np.isnan(full_data)]
-				num_points = len(full_data)
-				bin_centers = np.linspace(min_hz-1,max_hz+1,np.max([8,np.ceil(num_points/5).astype('int')]))
-				bins_calc = [bin_centers[0] - np.mean(np.diff(bin_centers))]
-				bins_calc.extend(bin_centers + np.mean(np.diff(bin_centers)))
-				fit_data = np.histogram(full_data,density=True,bins=bins_calc)
-				new_fit = interpolate.interp1d(bin_centers,fit_data[0],kind='linear')
-				filtered_data = new_fit(hist_bins)
-				filtered_data = filtered_data/np.sum(filtered_data) #return to a probability density
-				fit_tastant_neur[t_i,n_i,:] = filtered_data
-			del n_i, full_data, num_points, bin_centers, bins_calc, fit_data, new_fit, filtered_data
-		np.save(save_dir + 'fit_tastant_neur_full_taste_z.npy',fit_tastant_neur)
-	
-	#Fit the joint distribution across tastes
-	#print("\tFitting joint distribution by neuron")
-	try:
-		joint_fit_neur = np.load(save_dir + 'joint_fit_neur_full_taste_z.npy')
-		prev_run[1] = 1
-	except:
-		joint_fit_neur = np.zeros((num_neur,len(x_vals)+1))
-		for n_i in taste_select_neur:
-			all_taste_fr = (full_taste_fr_dist_z[:,n_i,:]).flatten()
-			all_taste_fr = all_taste_fr[~np.isnan(all_taste_fr)]
-			bin_centers = np.linspace(min_hz-1,max_hz+1)
-			bins_calc = [bin_centers[0] - np.mean(np.diff(bin_centers))]
-			bins_calc.extend(bin_centers + np.mean(np.diff(bin_centers)))
-			fit_data = np.histogram(all_taste_fr,density=True,bins=bins_calc)
-			new_fit = interpolate.interp1d(bin_centers,fit_data[0])
-			filtered_data = new_fit(hist_bins)
-			filtered_data = filtered_data/np.sum(filtered_data) #return to a probability density
-			joint_fit_neur[n_i,:] = filtered_data
-		del n_i, all_taste_fr, bin_centers, bins_calc, fit_data, new_fit, filtered_data
-		np.save(save_dir + 'joint_fit_neur_full_taste_z.npy',joint_fit_neur)
-	
-	if np.sum(prev_run) < 2:
-		#Plot the taste distributions against each other
-		fig_t, ax_t = plt.subplots(nrows=num_neur,ncols=1,sharex=True,figsize=(5,num_neur))
-		for n_i in taste_select_neur: 
-			if n_i == 0:	
-				ax_t[n_i].plot((fit_tastant_neur[:,n_i,:]).T,label=np.array(dig_in_names))
-				ax_t[n_i].plot((joint_fit_neur[n_i,:]).T,label='Joint Dist')
-				ax_t[n_i].legend()
-			else:
-				ax_t[n_i].plot((fit_tastant_neur[:,n_i,:]).T)
-				ax_t[n_i].plot((joint_fit_neur[n_i,:]).T,label='Joint Dist')
-				ax_t[n_i].legend()
-		ax_t[num_neur-1].set_xlabel('Firing Rate (Hz)')
-		fig_t.supylabel('Probability')
-		fig_t.tight_layout()
-		fig_t.savefig(save_dir + 'full_taste_fr_dist_fits_z.png')
-		fig_t.savefig(save_dir + 'full_taste_fr_dist_fits_z.svg')
-		plt.close(fig_t)
-	
-	#Segment-by-segment use sliding bin with a skip
-	seg_decode_save_dir = save_dir + 'decode_prob_full_taste/'
-	if not os.path.isdir(seg_decode_save_dir):
-		os.mkdir(seg_decode_save_dir)
-	for s_i in range(num_segments):
-		try:
-			seg_decode_prob = np.load(seg_decode_save_dir + 'segment_' + str(s_i) + '.npy')
-			print("Segment " + str(s_i) + " Previously Decoded")
-		except:
-			print("Decoding Segment " + str(s_i))
-			seg_start = segment_times[s_i]
-			seg_end = segment_times[s_i+1]
-			seg_len = seg_end - seg_start
-			#Segment mean and std firing rates
-			time_bin_starts_z = np.arange(seg_start+half_bin_z,seg_end-half_bin_z,half_bin_z*2)
-			segment_spike_times_s_i = segment_spike_times[s_i]
-			segment_spike_times_s_i_bin = np.zeros((num_neur,seg_len+1))
-			for n_i in range(num_neur):
-				n_i_spike_times = np.array(segment_spike_times_s_i[n_i] - seg_start).astype('int')
-				segment_spike_times_s_i_bin[n_i,n_i_spike_times] = 1
-			tb_fr = np.zeros((num_neur,len(time_bin_starts_z)))
-			for tb_i,tb in enumerate(tqdm.tqdm(time_bin_starts_z)):
-				tb_fr[:,tb_i] = np.sum(segment_spike_times_s_i_bin[:,tb-seg_start-half_bin_z:tb+half_bin_z-seg_start],1)/(2*half_bin_z*(1/1000))
-			mean_fr = np.mean(tb_fr,1)
-			std_fr = np.std(tb_fr,1)
-			#Decode
-			time_bin_starts = np.arange(seg_start+half_bin,seg_end-half_bin,skip_dt)
-			num_times = len(time_bin_starts)
-			seg_decode_prob = np.zeros((num_tastes,seg_len+1))
-			try:
-				tb_fr = np.load(seg_decode_save_dir + 'segment_' + str(s_i) + '_tb_fr.npy')
-			except:
-				tb_fr = np.zeros((num_neur,len(time_bin_starts)))
-				for tb_i,tb in enumerate(tqdm.tqdm(time_bin_starts)):
-					tb_fr_orig = np.sum(segment_spike_times_s_i_bin[:,tb-seg_start-half_bin:tb+half_bin-seg_start],1)/(2*half_bin*(1/1000))
-					tb_fr[:,tb_i] = (tb_fr_orig - mean_fr)/std_fr
-				del tb_i, tb
-				np.save(seg_decode_save_dir + 'segment_' + str(s_i) + '_tb_fr.npy',tb_fr)
-			list_tb_fr = list(tb_fr.T)
-			del tb_fr
-			#Pass inputs to parallel computation on probabilities
-			inputs = zip(list_tb_fr, itertools.repeat(num_tastes), \
-				 itertools.repeat(num_neur),itertools.repeat(x_vals), \
-				 itertools.repeat(fit_tastant_neur), itertools.repeat(joint_fit_neur), \
-				 itertools.repeat(p_taste),itertools.repeat(taste_select_neur))
-			tic = time.time()
-			pool = Pool(4)
-			tb_decode_prob = pool.map(dp.segment_taste_decode_parallelized, inputs)
-			pool.close()
-			toc = time.time()
-			print('\t\tTime to decode = ' + str(np.round((toc-tic)/60,2)) + ' (min)')
-			tb_decode_array = np.squeeze(np.array(tb_decode_prob)).T
-			#___
-			for s_dt in range(skip_dt): #The whole skip interval should have the same decode probability
-				seg_decode_prob[:,time_bin_starts - seg_start + s_dt] = tb_decode_array
-			
-			#Save decoding probabilities
-			np.save(seg_decode_save_dir + 'segment_' + str(s_i) + '.npy',seg_decode_prob)
-			
-			#Create plots
-			all_time = np.arange(seg_start,seg_end+1)
-			seg_decode_taste_ind = np.argmax(seg_decode_prob,0)
-			seg_decode_taste_bin = np.zeros(np.shape(seg_decode_prob))
-			for t_i in range(num_tastes):
-				seg_decode_taste_bin[t_i,np.where(seg_decode_taste_ind == t_i)[0]] = 1
-			#Line plot
-			f1 = plt.figure()
-			plt.plot(all_time/1000/60,seg_decode_prob.T)
-			for t_i in range(num_tastes):
-				plt.fill_between(all_time/1000/60,seg_decode_taste_bin[t_i,:],alpha=0.2)
-			plt.legend(dig_in_names,loc='right')
-			plt.ylabel('Decoding Fraction')
-			plt.xlabel('Time (min)')
-			plt.title('Segment ' + str(s_i))
-			f1.savefig(seg_decode_save_dir + 'segment_' + str(s_i) + '.png')
-			f1.savefig(seg_decode_save_dir + 'segment_' + str(s_i) + '.svg')
-			plt.close(f1)
-			#Imshow
-			f2 = plt.figure()
-			plt.imshow(seg_decode_prob,aspect='auto',interpolation = 'none')
-			x_ticks = np.ceil(np.linspace(0,seg_len,10)).astype('int')
-			x_tick_labels = np.round(all_time[x_ticks]/1000/60,2)
-			plt.xticks(x_ticks,x_tick_labels)
-			y_ticks = np.arange(len(dig_in_names))
-			plt.yticks(y_ticks,dig_in_names)
-			plt.ylabel('Decoding Fraction')
-			plt.xlabel('Time (min)')
-			plt.title('Segment ' + str(s_i))
-			f2.savefig(seg_decode_save_dir + 'segment_' + str(s_i) + '_im.png')
-			f2.savefig(seg_decode_save_dir + 'segment_' + str(s_i) + '_im.svg')
-			plt.close(f2)
-			#Fraction of occurrences
-			f3 = plt.figure()
-			plt.pie(np.sum(seg_decode_taste_bin,1)/np.sum(seg_decode_taste_bin),labels=['water','saccharin','none'],autopct='%1.1f%%')
-			plt.title('Segment ' + str(s_i))
-			f3.savefig(seg_decode_save_dir + 'segment_' + str(s_i) + '_pie.png')
-			f3.savefig(seg_decode_save_dir + 'segment_' + str(s_i) + '_pie.svg')
-			plt.close(f3)
-			#If it's the taste interval, save separately decoding of each taste delivery
-			if segment_names[s_i].lower() == 'taste': #Assumes it's always called just "taste"
-				#Create taste decode dir
-				seg_taste_decode_save_dir = seg_decode_save_dir + 'taste_decode/'
-				if not os.path.isdir(seg_taste_decode_save_dir):
-					os.mkdir(seg_taste_decode_save_dir)
-				for t_i in range(num_tastes): #Do each taste and find if match
-					for st_i,st in enumerate(np.array(start_dig_in_times[t_i])):
-						#Plot the decoding to [-post_taste_dt,2*post_taste_dt] around delivery
-						f4 = plt.figure()
-						start_dec_t = max(st - post_taste_dt,seg_start)
-						closest_tbs = np.argmin(np.abs(time_bin_starts - start_dec_t))
-						end_dec_t = min(st + 2*post_taste_dt,seg_end)
-						closest_tbe = np.argmin(np.abs(time_bin_starts - end_dec_t))
-						closest_td = np.argmin(np.abs(time_bin_starts - st))
-						decode_tbs = np.arange(closest_tbs,closest_tbe)
-						decode_t = time_bin_starts[decode_tbs]
-						decode_t_labels = decode_t - st #in ms
-						decode_snip = seg_decode_prob[:,decode_tbs]
-						plt.plot(decode_t_labels,decode_snip.T)
-						for t_i_2 in range(num_tastes):
-							plt.fill_between(decode_t_labels,decode_snip[t_i_2,:],alpha=0.2)
-						plt.axvline(0)
-						plt.legend(dig_in_names)
-						plt.ylabel('Decoding Fraction')
-						plt.xlabel('Time From Delivery (ms)')
-						plt.title(dig_in_names[t_i] + ' delivery #' + str(st_i))
-						f4.savefig(seg_taste_decode_save_dir + dig_in_names[t_i] + '_' + str(st_i) + '.png')
-						f4.savefig(seg_taste_decode_save_dir + dig_in_names[t_i] + '_' + str(st_i) + '.svg')
-						plt.close(f4)
-
-
+	return tastant_fr_dist_pop, max_hz_pop, min_hz_pop, taste_num_deliv
 
 
 def decode_epochs_zscore(tastant_fr_dist_z,segment_spike_times,post_taste_dt,
@@ -1616,8 +1055,7 @@ def decode_epochs_zscore(tastant_fr_dist_z,segment_spike_times,post_taste_dt,
 						plt.close(f4)
 
 
-
-		
+	
 def plot_decoded(fr_dist,num_tastes,num_neur,num_cp,segment_spike_times,tastant_spike_times,
 				 start_dig_in_times,end_dig_in_times,post_taste_dt,pop_taste_cp_raster_inds,
 				 e_skip_dt,e_len_dt,dig_in_names,segment_times,
@@ -1734,7 +1172,7 @@ def plot_decoded(fr_dist,num_tastes,num_neur,num_cp,segment_spike_times,tastant_
 							d_i_spikes = np.array(taste_spike_times[d_i][n_i] - taste_deliv_times[d_i]).astype('int')
 						if len(d_i_spikes) > 0:
 							taste_spike_times_bin[d_i,n_i,d_i_spikes[d_i_spikes<post_taste_dt]] = 1
-					taste_cp_times[d_i,:] = np.concatenate((np.cumsum(np.diff(pop_taste_cp_times[d_i,:])),post_taste_dt*np.ones(1))).astype('int')
+					taste_cp_times[d_i,:] = np.concatenate((np.zeros(1),np.cumsum(np.diff(pop_taste_cp_times[d_i,:])))).astype('int')
 					#Calculate the FR vectors by epoch for each taste response and the average FR vector
 					taste_epoch_fr_vecs[d_i,:] = np.sum(taste_spike_times_bin[d_i,:,taste_cp_times[d_i,e_i]:taste_cp_times[d_i,e_i+1]],1)/((taste_cp_times[d_i,e_i+1]-taste_cp_times[d_i,e_i])/1000) #FR in HZ
 				all_taste_fr_vecs.append(taste_epoch_fr_vecs)

--- a/functions/dependent_decoding_funcs.py
+++ b/functions/dependent_decoding_funcs.py
@@ -39,19 +39,15 @@ def taste_fr_dist(num_neur,num_cp,tastant_spike_times,pop_taste_cp_raster_inds,
 	del t_i, num_deliv
 	
 	#Set up storage dictionary of results
-	full_taste_fr_dist = dict() #Full taste response firing rate distribution
 	tastant_fr_dist = dict() #Population firing rate distributions by epoch
 	for t_i in range(num_tastes):
-		full_taste_fr_dist[t_i] = dict()
 		tastant_fr_dist[t_i] = dict()
 		for d_i in range(max_num_deliv):
-			full_taste_fr_dist[t_i][d_i] = dict()
 			tastant_fr_dist[t_i][d_i] = dict()
 			for cp_i in range(num_cp):
 				tastant_fr_dist[t_i][d_i][cp_i] = dict()
 					
 	max_hz = 0
-	max_hz_full = 0
 	for t_i in range(num_tastes):
 		num_deliv = taste_num_deliv[t_i]
 		taste_cp = pop_taste_cp_raster_inds[t_i]
@@ -71,20 +67,6 @@ def taste_fr_dist(num_neur,num_cp,tastant_spike_times,pop_taste_cp_raster_inds,
 					start_epoch = int(deliv_cp[cp_i])
 					end_epoch = int(deliv_cp[cp_i+1])
 					#TODO: add variable to change the bin size
-					#____Toddler block____
-# 					bin_edges = np.arange(start_epoch,end_epoch,100).astype('int') #bin the epoch
-# 					if len(bin_edges) != 0:
-# 						if (bin_edges[-1] != end_epoch)*(end_epoch-bin_edges[-1]>10):
-# 							bin_edges = np.concatenate((bin_edges,end_epoch*np.ones(1).astype('int')))
-# 						#Calculate population firing rate vectors within bins
-# 						bst_hz = np.array([np.sum(bin_post_taste[:,bin_edges[b_i]:bin_edges[b_i+1]],1)/((bin_edges[b_i+1] - bin_edges[b_i])*(1/1000)) for b_i in range(len(bin_edges)-1)])
-# 						#Store the firing rate vectors
-# 						tastant_fr_dist[t_i][d_i][cp_i] = bst_hz
-# 						#Store maximum firing rate
-# 						if np.max(bst_hz) > max_hz:
-# 							max_hz = np.max(bst_hz)
-					#____
-					#____Teen block____
 					bin_starts = np.arange(start_epoch,end_epoch-100).astype('int') #bin the epoch
 					if len(bin_starts) != 0:
 						#Calculate population firing rate vectors within bins
@@ -94,29 +76,8 @@ def taste_fr_dist(num_neur,num_cp,tastant_spike_times,pop_taste_cp_raster_inds,
 						#Store maximum firing rate
 						if np.max(bst_hz) > max_hz:
 							max_hz = np.max(bst_hz)
-					#____
-			#Calculate full taste interval firing rate vectors
-			#____Toddler block____
-# 			bin_edges = np.arange(0,post_taste_dt,100).astype('int') #bin the epoch
-# 			if len(bin_edges) != 0:
-# 				if (bin_edges[-1] != post_taste_dt)*(post_taste_dt-bin_edges[-1]>10):
-# 					bin_edges = np.concatenate((bin_edges,post_taste_dt*np.ones(1).astype('int')))
-# 				bst_hz = np.array([np.sum(bin_post_taste[:,bin_edges[b_i]:bin_edges[b_i+1]],1)/((bin_edges[b_i+1] - bin_edges[b_i])*(1/1000)) for b_i in range(len(bin_edges)-1)])
-# 				full_taste_fr_dist[t_i][d_i] = bst_hz.T
-# 				if np.max(bst_hz) > max_hz_full:
-# 					max_hz_full = np.max(bst_hz)
-			#____
-			#____Teen block____
-			bin_starts = np.arange(0,post_taste_dt-100).astype('int') #bin the epoch
-			if len(bin_starts) != 0:
-				bst_hz = np.array([np.sum(bin_post_taste[:,bin_starts[b_i]:bin_starts[b_i]+100],1)/(100/1000) for b_i in range(len(bin_starts))])
-				full_taste_fr_dist[t_i][d_i] = bst_hz.T
-				if np.max(bst_hz) > max_hz_full:
-					max_hz_full = np.max(bst_hz)
-			#____
-			
 					
-	return tastant_fr_dist, full_taste_fr_dist, taste_num_deliv, max_hz, max_hz_full
+	return tastant_fr_dist, taste_num_deliv, max_hz
 	
 def decode_epochs(tastant_fr_dist,segment_spike_times,post_taste_dt,
 				   skip_dt,e_skip_dt,e_len_dt,dig_in_names,segment_times,
@@ -364,21 +325,16 @@ def taste_fr_dist_zscore(num_neur,num_cp,tastant_spike_times,segment_spike_times
 		
 	#Determine the spike fr distributions for each neuron for each taste
 	#print("\tPulling spike fr distributions by taste by neuron")
-	full_taste_fr_dist = dict() #Full taste response firing rate distribution
 	tastant_fr_dist = dict() #Population firing rate distributions by epoch
 	for t_i in range(num_tastes):
-		full_taste_fr_dist[t_i] = dict()
 		tastant_fr_dist[t_i] = dict()
 		for d_i in range(max_num_deliv):
-			full_taste_fr_dist[t_i][d_i] = dict()
 			tastant_fr_dist[t_i][d_i] = dict()
 			for cp_i in range(num_cp):
 				tastant_fr_dist[t_i][d_i][cp_i] = dict()
 	#____
 	max_hz = 0
 	min_hz = 0
-	max_hz_full = 0
-	min_hz_full = 0
 	for t_i in range(num_tastes):
 		num_deliv = taste_num_deliv[t_i]
 		taste_cp = pop_taste_cp_raster_inds[t_i]
@@ -408,21 +364,10 @@ def taste_fr_dist_zscore(num_neur,num_cp,tastant_spike_times,segment_spike_times
 					if np.min(bst_hz_z) < min_hz:
 						min_hz = np.min(bst_hz_z)
 			del cp_i, start_epoch, end_epoch, bst_hz, bst_hz_z
-			bin_edges = np.arange(0,post_taste_dt,100).astype('int') #bin the epoch
-			if len(bin_edges) != 0:
-				if (bin_edges[-1] != post_taste_dt)*(post_taste_dt-bin_edges[-1]>10):
-					bin_edges = np.concatenate((bin_edges,post_taste_dt*np.ones(1).astype('int')))
-				bst_hz = [np.sum(bin_post_taste[:,bin_edges[b_i]:bin_edges[b_i+1]],1)/((bin_edges[b_i+1] - bin_edges[b_i])*(1/1000)) for b_i in range(len(bin_edges)-1)]
-				bst_hz_z = (np.array(bst_hz).T - np.expand_dims(mean_fr,1))/np.expand_dims(std_fr,1)
-				full_taste_fr_dist[t_i][d_i] = bst_hz_z
-				if np.max(bst_hz_z) > max_hz_full:
-					max_hz_full = np.max(bst_hz_z)
-				if np.min(bst_hz_z) < min_hz_full:
-					min_hz_full = np.max(bst_hz_z)
+			
 	del t_i, num_deliv, taste_cp, n_i, d_i, raster_times, start_taste_i, deliv_cp, times_post_taste, bin_post_taste
 
-	return full_taste_fr_dist, tastant_fr_dist, taste_num_deliv, max_hz, \
-		max_hz_full, min_hz, min_hz_full
+	return tastant_fr_dist, taste_num_deliv, max_hz, min_hz
 
 
 def decode_epochs_zscore(tastant_fr_dist_z,segment_spike_times,post_taste_dt,

--- a/functions/dependent_decoding_funcs.py
+++ b/functions/dependent_decoding_funcs.py
@@ -40,7 +40,7 @@ def taste_fr_dist(num_neur,num_cp,tastant_spike_times,pop_taste_cp_raster_inds,
 	
 	#If trial_start_frac > 0 use only trials after that threshold
 	trial_start_ind = np.floor(max_num_deliv*trial_start_frac).astype('int')
-	new_max_num_deliv = max_num_deliv - trial_start_ind
+	new_max_num_deliv = (max_num_deliv - trial_start_ind).astype('int')
 	
 	#Set up storage dictionary of results
 	tastant_fr_dist = dict() #Population firing rate distributions by epoch
@@ -307,7 +307,7 @@ def taste_fr_dist_zscore(num_neur,num_cp,tastant_spike_times,segment_spike_times
 	
 	#If trial_start_frac > 0 use only trials after that threshold
 	trial_start_ind = np.floor(max_num_deliv*trial_start_frac).astype('int')
-	new_max_num_deliv = max_num_deliv - trial_start_ind
+	new_max_num_deliv = (max_num_deliv - trial_start_ind).astype('int')
 	
 	deliv_taste_index = []
 	taste_num_deliv = np.zeros(num_tastes)
@@ -356,7 +356,7 @@ def taste_fr_dist_zscore(num_neur,num_cp,tastant_spike_times,segment_spike_times
 	max_hz = 0
 	min_hz = 0
 	for t_i in range(num_tastes):
-		num_deliv = taste_num_deliv[t_i]
+		num_deliv = (taste_num_deliv[t_i]).astype('int')
 		taste_cp = pop_taste_cp_raster_inds[t_i]
 		for d_i in range(num_deliv): #index for that taste
 			if d_i >= trial_start_ind:
@@ -400,7 +400,7 @@ def decode_epochs_zscore(tastant_fr_dist_z,segment_spike_times,post_taste_dt,
 	#Variables
 	num_tastes = len(start_dig_in_times)
 	num_neur = len(segment_spike_times[0])
-	max_num_deliv = np.max(taste_num_deliv)
+	max_num_deliv = np.max(taste_num_deliv).astype('int')
 	num_cp = len(tastant_fr_dist_z[0][0])
 	num_segments = len(segment_spike_times)
 	hist_bins = np.arange(stop=max_hz+1,step=0.25)
@@ -411,7 +411,7 @@ def decode_epochs_zscore(tastant_fr_dist_z,segment_spike_times,post_taste_dt,
 
 	#If trial_start_frac > 0 use only trials after that threshold
 	trial_start_ind = np.floor(max_num_deliv*trial_start_frac).astype('int')
-	new_max_num_deliv = max_num_deliv - trial_start_ind
+	new_max_num_deliv = (max_num_deliv - trial_start_ind).astype('int')
 
 	for e_i in range(num_cp): #By epoch conduct decoding
 		print('Decoding Epoch ' + str(e_i))

--- a/functions/plot_funcs.py
+++ b/functions/plot_funcs.py
@@ -548,25 +548,53 @@ def taste_response_similarity_plots(num_tastes,num_cp,num_neur,num_segments,
 			#___Correlations
 			#Correlation matrix
 			corr_mat = np.zeros((num_deliv,num_deliv))
-			for d_1 in range(num_deliv-1): #First delivery
+			for d_1 in range(num_deliv): #First delivery
 				t_vec_1 = taste_epoch_fr_vecs[d_1,:]
 				for d_2 in np.arange(d_1,num_deliv): #Second delivery
 					t_vec_2 = taste_epoch_fr_vecs[d_2,:]
 					corr_mat[d_1,d_2] = np.abs(pearsonr(t_vec_1,t_vec_2)[0])
 			#Correlation timeseries average
-			corr_mean_vec = np.nansum(corr_mat,0)/np.arange(1,num_deliv+1)
+			corr_mean_vec_pre = np.nansum(corr_mat,0)/np.arange(1,num_deliv+1)
+			corr_mean_vec_post = np.nansum(corr_mat,1).T/np.flip(np.arange(1,num_deliv+1))
+			#Rolling correlation average for block of 5
+			corr_block_mean_pre = np.nan*np.ones(num_deliv)
+			corr_block_mean_post = np.nan*np.ones(num_deliv)
+			for b_i in range(num_deliv):
+				try:
+					corr_block_mean_pre[b_i] = np.nansum(corr_mat[b_i-5:b_i,b_i])/5
+				except:
+					"do nothing"
+				try:
+					corr_block_mean_post[b_i] = np.nansum(corr_mat[b_i,b_i:b_i+5])/5
+				except:
+					"do nothing"
 			#Indiv taste deliv similarity/correlation plots
-			f,ax = plt.subplots(nrows=2,ncols=1,figsize=(8,8),gridspec_kw=dict(height_ratios=[3,1]))
+			f,ax = plt.subplots(nrows=5,ncols=1,figsize=(10,10),gridspec_kw=dict(height_ratios=[10,1,1,1,1]))
 			img = ax[0].imshow(corr_mat,cmap='binary')
 			plt.colorbar(img, ax=ax[0],location='right')
 			ax[0].set_title('epoch ' + str(e_i) + ' ' + dig_in_names[t_i] + ' delivery correlation')
 			ax[0].set_xlabel('Delivery Index')
 			ax[0].set_ylabel('Delivery Index')
-			ax[1].plot(np.arange(num_deliv),corr_mean_vec)
+			ax[1].plot(np.arange(num_deliv),corr_mean_vec_pre)
 			#ax[1].set_ylim([0,1])
 			ax[1].set_title('Average corr of pre to given index')
 			ax[1].set_xlabel('Delivery Index')
 			ax[1].set_ylabel('Correlation')
+			ax[2].plot(np.arange(num_deliv),corr_mean_vec_post)
+			#ax[2].set_ylim([0,1])
+			ax[2].set_title('Average corr of post to given index')
+			ax[2].set_xlabel('Delivery Index')
+			ax[2].set_ylabel('Correlation')
+			ax[3].plot(np.arange(5,num_deliv),corr_block_mean_pre[5:])
+			#ax[3].set_ylim([0,1])
+			ax[3].set_title('Average 5-trial corr of pre to given index')
+			ax[3].set_xlabel('Delivery Index')
+			ax[3].set_ylabel('Correlation')
+			ax[4].plot(np.arange(num_deliv-5),corr_block_mean_post[:-5])
+			#ax[4].set_ylim([0,1])
+			ax[4].set_title('Average 5-trial corr of post to given index')
+			ax[4].set_xlabel('Delivery Index')
+			ax[4].set_ylabel('Correlation')
 			plt.tight_layout()
 			f.savefig(epoch_save_dir + dig_in_names[t_i] + '_deliv_correlation_mat.png')
 			f.savefig(epoch_save_dir + dig_in_names[t_i] + '_deliv_correlation_mat.svg')
@@ -574,25 +602,53 @@ def taste_response_similarity_plots(num_tastes,num_cp,num_neur,num_segments,
 			#___Distances
 			#Distance matrix
 			dist_mat = np.zeros((num_deliv,num_deliv))
-			for d_1 in range(num_deliv-1): #First delivery
+			for d_1 in range(num_deliv): #First delivery
 				t_vec_1 = taste_epoch_fr_vecs[d_1,:]
 				for d_2 in np.arange(d_1,num_deliv): #Second delivery
 					t_vec_2 = taste_epoch_fr_vecs[d_2,:]
 					dist_mat[d_1,d_2] = np.sqrt(np.sum((t_vec_1-t_vec_2)**2))
 			#Distance timeseries average
-			dist_mean_vec = np.nansum(dist_mat,0)/np.arange(1,num_deliv+1)
+			dist_mean_vec_pre = np.nansum(dist_mat,0)/np.arange(1,num_deliv+1)
+			dist_mean_vec_post = np.nansum(dist_mat,1).T/np.flip(np.arange(1,num_deliv+1))
+			#Rolling correlation average for block of 5
+			dist_block_mean_pre = np.nan*np.ones(num_deliv)
+			dist_block_mean_post = np.nan*np.ones(num_deliv)
+			for b_i in range(num_deliv):
+				try:
+					dist_block_mean_pre[b_i] = np.nansum(dist_mat[b_i-5:b_i,b_i])/5
+				except:
+					"do nothing"
+				try:
+					dist_block_mean_post[b_i] = np.nansum(dist_mat[b_i,b_i:b_i+5])/5
+				except:
+					"do nothing"
 			#Indiv taste deliv distance plots
-			f,ax = plt.subplots(nrows=2,ncols=1,figsize=(8,8),gridspec_kw=dict(height_ratios=[3,1]))
+			f,ax = plt.subplots(nrows=5,ncols=1,figsize=(10,10),gridspec_kw=dict(height_ratios=[10,1,1,1,1]))
 			img = ax[0].imshow(dist_mat,cmap='binary')
 			plt.colorbar(img, ax=ax[0],location='right')
 			ax[0].set_title('epoch ' + str(e_i) + ' ' + dig_in_names[t_i] + ' delivery distance')
 			ax[0].set_xlabel('Delivery Index')
 			ax[0].set_ylabel('Delivery Index')
-			ax[1].plot(np.arange(num_deliv),dist_mean_vec)
+			ax[1].plot(np.arange(num_deliv),dist_mean_vec_pre)
 			#ax[1].set_ylim([0,1])
 			ax[1].set_title('Average distance of pre to given index')
 			ax[1].set_xlabel('Delivery Index')
 			ax[1].set_ylabel('Distance')
+			ax[2].plot(np.arange(num_deliv),dist_mean_vec_post)
+			#ax[2].set_ylim([0,1])
+			ax[2].set_title('Average distance of post to given index')
+			ax[2].set_xlabel('Delivery Index')
+			ax[2].set_ylabel('Distance')
+			ax[3].plot(np.arange(5,num_deliv),dist_block_mean_pre[5:])
+			#ax[3].set_ylim([0,1])
+			ax[3].set_title('Average 5-trial distance of pre to given index')
+			ax[3].set_xlabel('Delivery Index')
+			ax[3].set_ylabel('Distance')
+			ax[4].plot(np.arange(num_deliv-5),dist_block_mean_post[:-5])
+			#ax[4].set_ylim([0,1])
+			ax[4].set_title('Average 5-trial distance of post to given index')
+			ax[4].set_xlabel('Delivery Index')
+			ax[4].set_ylabel('Distance')
 			plt.tight_layout()
 			f.savefig(epoch_save_dir + dig_in_names[t_i] + '_deliv_distance_mat.png')
 			f.savefig(epoch_save_dir + dig_in_names[t_i] + '_deliv_distance_mat.svg')


### PR DESCRIPTION
Updated dependent decoding pipeline to allow for setting a starting trial threshold. Only those trials >= that fractional index of all trials will be used for decoding and plotting.

Other:
- Slight rearrangement + cleanup of older codes that will not be used for decoding.
- Minor bug fix to deal with new changepoint storage properly in plot funcs.

Minor plot edits:
- change colormap for tastes in decoding plots
- update background fill to only where decoding is above 0.95
- calculate the correlation of a decoded event to the average taste response and add to title