### PR TITLE
Decoder Prior Updates + Extras

### DIFF
--- a/analyze_states.py
+++ b/analyze_states.py
@@ -96,7 +96,7 @@ except:
 #distribution (taken from Paul's Comp Neuro Textbook)
 
 cp_bin = 300 #minimum state size in ms
-num_cp = 2 #number of changepoints to find
+num_cp = 2 #number of changepoints to find (this means number of epochs is num_cp + 1)
 before_taste = np.ceil(pre_taste*1000).astype('int') #Milliseconds before taste delivery to plot
 after_taste = np.ceil(post_taste*1000).astype('int') #Milliseconds after taste delivery to plot
 
@@ -155,7 +155,7 @@ except:
 
 data_group_name = 'taste_selectivity'
 
-tastant_binned_frs = af.taste_cp_frs(taste_cp_raster_inds,tastant_spike_times,start_dig_in_times,end_dig_in_times,dig_in_names,num_neur,pre_taste_dt,post_taste_dt)
+#tastant_binned_frs = af.taste_cp_frs(taste_cp_raster_inds,tastant_spike_times,start_dig_in_times,end_dig_in_times,dig_in_names,num_neur,pre_taste_dt,post_taste_dt)
 
 decoding_save_dir = data_save_dir + 'Taste_Selectivity/'
 if os.path.isdir(decoding_save_dir) == False:
@@ -181,12 +181,12 @@ except:
 	#taste_select_prob_epoch = fraction of correctly decoded deliveries [num_cp, num_neur, num_tastes]
 	
 	p_taste_joint, p_taste_epoch, taste_select_prob_joint, taste_select_prob_epoch = df.taste_decoding_cp(tastant_spike_times,\
-												   pop_taste_cp_raster_inds,num_cp,start_dig_in_times,end_dig_in_times,dig_in_names, \
+												   pop_taste_cp_raster_inds,start_dig_in_times,end_dig_in_times,dig_in_names, \
 													   num_neur,pre_taste_dt,post_taste_dt,loo_distribution_save_dir)
 	#_____Calculate binary matrices of taste selective neurons / taste selective neurons by epoch_____
 	#On average, does the neuron decode neurons more often than chance?
-	taste_select_neur_bin = np.sum(taste_select_prob_joint,1) > 1/num_tastes
-	taste_select_neur_epoch_bin = np.sum(taste_select_prob_epoch,2) > 1/num_tastes
+	taste_select_neur_bin = np.sum(taste_select_prob_joint,1) > 1/(num_tastes-1)
+	taste_select_neur_epoch_bin = np.sum(taste_select_prob_epoch,2) > 1/(num_tastes-1)
 	#Save
 	af.add_data_to_hdf5(sorted_dir,data_group_name,'p_taste_joint',p_taste_joint)
 	af.add_data_to_hdf5(sorted_dir,data_group_name,'taste_select_prob_joint',taste_select_prob_joint)

--- a/bayes_replay_dependent_decoding.py
+++ b/bayes_replay_dependent_decoding.py
@@ -120,110 +120,110 @@ if __name__ == '__main__':
 
     # %%
 
-    # _____DECODE ALL NEURONS_____
-    print("\n===Decoding using all neurons.===\n")
+    # # _____DECODE ALL NEURONS_____
+    # print("\n===Decoding using all neurons.===\n")
 
-    bayes_dir_all = bayes_dir + 'All_Neurons/'
-    if os.path.isdir(bayes_dir_all) == False:
-        os.mkdir(bayes_dir_all)
+    # bayes_dir_all = bayes_dir + 'All_Neurons/'
+    # if os.path.isdir(bayes_dir_all) == False:
+    #     os.mkdir(bayes_dir_all)
 
-    taste_select = np.ones(num_neur)  # stand in to use full population
-    # stand in to use full population
-    taste_select_epoch = np.ones((num_cp, num_neur))
+    # taste_select = np.ones(num_neur)  # stand in to use full population
+    # # stand in to use full population
+    # taste_select_epoch = np.ones((num_cp, num_neur))
 
-    ddf.decode_epochs(tastant_fr_dist_pop, segment_spike_times, post_taste_dt,
-                      skip_dt, e_skip_dt, e_len_dt, dig_in_names, segment_times,
-                      segment_names, start_dig_in_times, taste_num_deliv,
-                      taste_select_epoch, use_full, max_hz_pop, bayes_dir_all,
-                      neuron_count_thresh, trial_start_frac, epochs_to_analyze,
-                      segments_to_analyze)
+    # ddf.decode_epochs(tastant_fr_dist_pop, segment_spike_times, post_taste_dt,
+    #                   skip_dt, e_skip_dt, e_len_dt, dig_in_names, segment_times,
+    #                   segment_names, start_dig_in_times, taste_num_deliv,
+    #                   taste_select_epoch, use_full, max_hz_pop, bayes_dir_all,
+    #                   neuron_count_thresh, trial_start_frac, epochs_to_analyze,
+    #                   segments_to_analyze)
 
-    # ___Plot Results___
+    # # ___Plot Results___
 
-    print("Plotting Results")
+    # print("Plotting Results")
 
-    df.plot_decoded(tastant_fr_dist_pop, num_tastes, num_neur, num_cp, segment_spike_times, tastant_spike_times,
-                    start_dig_in_times, end_dig_in_times, post_taste_dt, pre_taste_dt,
-                    pop_taste_cp_raster_inds,
-                    e_skip_dt, e_len_dt, dig_in_names, segment_times,
-                    segment_names, taste_num_deliv, taste_select_epoch,
-                    use_full, bayes_dir_all, max_decode, max_hz_pop, seg_stat_bin,
-                    neuron_count_thresh, trial_start_frac, epochs_to_analyze,
-                    segments_to_analyze, bin_pre_taste, decode_prob_cutoff)
+    # df.plot_decoded(tastant_fr_dist_pop, num_tastes, num_neur, num_cp, segment_spike_times, tastant_spike_times,
+    #                 start_dig_in_times, end_dig_in_times, post_taste_dt, pre_taste_dt,
+    #                 pop_taste_cp_raster_inds,
+    #                 e_skip_dt, e_len_dt, dig_in_names, segment_times,
+    #                 segment_names, taste_num_deliv, taste_select_epoch,
+    #                 use_full, bayes_dir_all, max_decode, max_hz_pop, seg_stat_bin,
+    #                 neuron_count_thresh, trial_start_frac, epochs_to_analyze,
+    #                 segments_to_analyze, bin_pre_taste, decode_prob_cutoff)
 
-    print("Plotting Results as a Function of Average Decoding Probability")
+    # print("Plotting Results as a Function of Average Decoding Probability")
 
-    df.plot_decoded_func_p(tastant_fr_dist_pop, num_tastes, num_neur, num_cp, segment_spike_times, tastant_spike_times,
-                           start_dig_in_times, end_dig_in_times, post_taste_dt, pop_taste_cp_raster_inds,
-                           e_skip_dt, e_len_dt, dig_in_names, segment_times,
-                           segment_names, taste_num_deliv, taste_select_epoch,
-                           use_full, bayes_dir_all, max_decode, max_hz_pop, seg_stat_bin,
-                           epochs_to_analyze, segments_to_analyze)
+    # df.plot_decoded_func_p(tastant_fr_dist_pop, num_tastes, num_neur, num_cp, segment_spike_times, tastant_spike_times,
+    #                        start_dig_in_times, end_dig_in_times, post_taste_dt, pop_taste_cp_raster_inds,
+    #                        e_skip_dt, e_len_dt, dig_in_names, segment_times,
+    #                        segment_names, taste_num_deliv, taste_select_epoch,
+    #                        use_full, bayes_dir_all, max_decode, max_hz_pop, seg_stat_bin,
+    #                        epochs_to_analyze, segments_to_analyze)
 
-    print("Plotting Results as a Function of Co-Active Neurons")
+    # print("Plotting Results as a Function of Co-Active Neurons")
 
-    df.plot_decoded_func_n(tastant_fr_dist_pop, num_tastes, num_neur, num_cp, segment_spike_times, tastant_spike_times,
-                           start_dig_in_times, end_dig_in_times, post_taste_dt, pop_taste_cp_raster_inds,
-                           e_skip_dt, e_len_dt, dig_in_names, segment_times,
-                           segment_names, taste_num_deliv, taste_select_epoch,
-                           use_full, bayes_dir_all, max_decode, max_hz_pop, seg_stat_bin,
-                           epochs_to_analyze, segments_to_analyze)
+    # df.plot_decoded_func_n(tastant_fr_dist_pop, num_tastes, num_neur, num_cp, segment_spike_times, tastant_spike_times,
+    #                        start_dig_in_times, end_dig_in_times, post_taste_dt, pop_taste_cp_raster_inds,
+    #                        e_skip_dt, e_len_dt, dig_in_names, segment_times,
+    #                        segment_names, taste_num_deliv, taste_select_epoch,
+    #                        use_full, bayes_dir_all, max_decode, max_hz_pop, seg_stat_bin,
+    #                        epochs_to_analyze, segments_to_analyze)
 
 # %%
 
-    # _____DECODE TASTE SELECTIVE NEURONS_____
-    print("\n===Now decoding using only taste selective neurons.===\n")
+#     # _____DECODE TASTE SELECTIVE NEURONS_____
+#     print("\n===Now decoding using only taste selective neurons.===\n")
 
-    data_group_name = 'taste_selectivity'
-    try:
-        taste_select_neur_bin = af.pull_data_from_hdf5(
-            sorted_dir, data_group_name, 'taste_select_neur_bin')[0]
-        taste_select_neur_epoch_bin = af.pull_data_from_hdf5(
-            sorted_dir, data_group_name, 'taste_select_neur_epoch_bin')[0]
-    except:
-        print("ERROR: No taste selective data.")
-        quit()
+#     data_group_name = 'taste_selectivity'
+#     try:
+#         taste_select_neur_bin = af.pull_data_from_hdf5(
+#             sorted_dir, data_group_name, 'taste_select_neur_bin')[0]
+#         taste_select_neur_epoch_bin = af.pull_data_from_hdf5(
+#             sorted_dir, data_group_name, 'taste_select_neur_epoch_bin')[0]
+#     except:
+#         print("ERROR: No taste selective data.")
+#         quit()
 
-    bayes_dir_select = bayes_dir + 'Taste_Selective/'
-    if os.path.isdir(bayes_dir_select) == False:
-        os.mkdir(bayes_dir_select)
+#     bayes_dir_select = bayes_dir + 'Taste_Selective/'
+#     if os.path.isdir(bayes_dir_select) == False:
+#         os.mkdir(bayes_dir_select)
 
-    ddf.decode_epochs(tastant_fr_dist_pop, segment_spike_times, post_taste_dt,
-                      skip_dt, e_skip_dt, e_len_dt, dig_in_names, segment_times,
-                      segment_names, start_dig_in_times, taste_num_deliv,
-                      taste_select_neur_epoch_bin, use_full, max_hz_pop, bayes_dir_select,
-                      neuron_count_thresh, trial_start_frac, epochs_to_analyze,
-                      segments_to_analyze)
+#     ddf.decode_epochs(tastant_fr_dist_pop, segment_spike_times, post_taste_dt,
+#                       skip_dt, e_skip_dt, e_len_dt, dig_in_names, segment_times,
+#                       segment_names, start_dig_in_times, taste_num_deliv,
+#                       taste_select_neur_epoch_bin, use_full, max_hz_pop, bayes_dir_select,
+#                       neuron_count_thresh, trial_start_frac, epochs_to_analyze,
+#                       segments_to_analyze)
 
-    print("Plotting Results")
+#     print("Plotting Results")
 
-    df.plot_decoded(tastant_fr_dist_pop, num_tastes, num_neur, num_cp, segment_spike_times, tastant_spike_times,
-                    start_dig_in_times, end_dig_in_times, post_taste_dt, pre_taste_dt,
-                    pop_taste_cp_raster_inds,
-                    e_skip_dt, e_len_dt, dig_in_names, segment_times,
-                    segment_names, taste_num_deliv, taste_select_neur_epoch_bin,
-                    use_full, bayes_dir_select, max_decode, max_hz_pop, seg_stat_bin,
-                    neuron_count_thresh, trial_start_frac,
-                    epochs_to_analyze, segments_to_analyze,
-                    bin_pre_taste, decode_prob_cutoff)
+#     df.plot_decoded(tastant_fr_dist_pop, num_tastes, num_neur, num_cp, segment_spike_times, tastant_spike_times,
+#                     start_dig_in_times, end_dig_in_times, post_taste_dt, pre_taste_dt,
+#                     pop_taste_cp_raster_inds,
+#                     e_skip_dt, e_len_dt, dig_in_names, segment_times,
+#                     segment_names, taste_num_deliv, taste_select_neur_epoch_bin,
+#                     use_full, bayes_dir_select, max_decode, max_hz_pop, seg_stat_bin,
+#                     neuron_count_thresh, trial_start_frac,
+#                     epochs_to_analyze, segments_to_analyze,
+#                     bin_pre_taste, decode_prob_cutoff)
 
-    print("Plotting Results as a Function of Average Decoding Probability")
+#     print("Plotting Results as a Function of Average Decoding Probability")
 
-    df.plot_decoded_func_p(tastant_fr_dist_pop, num_tastes, num_neur, num_cp, segment_spike_times, tastant_spike_times,
-                           start_dig_in_times, end_dig_in_times, post_taste_dt, pop_taste_cp_raster_inds,
-                           e_skip_dt, e_len_dt, dig_in_names, segment_times,
-                           segment_names, taste_num_deliv, taste_select_epoch,
-                           use_full, bayes_dir_select, max_decode, max_hz_pop, seg_stat_bin,
-                           epochs_to_analyze, segments_to_analyze)
+#     df.plot_decoded_func_p(tastant_fr_dist_pop, num_tastes, num_neur, num_cp, segment_spike_times, tastant_spike_times,
+#                            start_dig_in_times, end_dig_in_times, post_taste_dt, pop_taste_cp_raster_inds,
+#                            e_skip_dt, e_len_dt, dig_in_names, segment_times,
+#                            segment_names, taste_num_deliv, taste_select_epoch,
+#                            use_full, bayes_dir_select, max_decode, max_hz_pop, seg_stat_bin,
+#                            epochs_to_analyze, segments_to_analyze)
 
-    print("Plotting Results as a Function of Co-Active Neurons")
+#     print("Plotting Results as a Function of Co-Active Neurons")
 
-    df.plot_decoded_func_n(tastant_fr_dist_pop, num_tastes, num_neur, num_cp, segment_spike_times, tastant_spike_times,
-                           start_dig_in_times, end_dig_in_times, post_taste_dt, pop_taste_cp_raster_inds,
-                           e_skip_dt, e_len_dt, dig_in_names, segment_times,
-                           segment_names, taste_num_deliv, taste_select_epoch,
-                           use_full, bayes_dir_select, max_decode, max_hz_pop, seg_stat_bin,
-                           epochs_to_analyze, segments_to_analyze)
+#     df.plot_decoded_func_n(tastant_fr_dist_pop, num_tastes, num_neur, num_cp, segment_spike_times, tastant_spike_times,
+#                            start_dig_in_times, end_dig_in_times, post_taste_dt, pop_taste_cp_raster_inds,
+#                            e_skip_dt, e_len_dt, dig_in_names, segment_times,
+#                            segment_names, taste_num_deliv, taste_select_epoch,
+#                            use_full, bayes_dir_select, max_decode, max_hz_pop, seg_stat_bin,
+#                            epochs_to_analyze, segments_to_analyze)
 
 
 # %%
@@ -276,55 +276,55 @@ if __name__ == '__main__':
 
 
 # %%
-    # _____DECODE TASTE SELECTIVE NEURONS Z-SCORED_____
-    print("\n===Now decoding using only taste selective neurons z-scored.===\n")
+#     # _____DECODE TASTE SELECTIVE NEURONS Z-SCORED_____
+#     print("\n===Now decoding using only taste selective neurons z-scored.===\n")
 
-    data_group_name = 'taste_selectivity'
-    try:
-        taste_select_neur_bin = af.pull_data_from_hdf5(
-            sorted_dir, data_group_name, 'taste_select_neur_bin')[0]
-        taste_select_neur_epoch_bin = af.pull_data_from_hdf5(
-            sorted_dir, data_group_name, 'taste_select_neur_epoch_bin')[0]
-    except:
-        print("ERROR: No taste selective data.")
-        quit()
+#     data_group_name = 'taste_selectivity'
+#     try:
+#         taste_select_neur_bin = af.pull_data_from_hdf5(
+#             sorted_dir, data_group_name, 'taste_select_neur_bin')[0]
+#         taste_select_neur_epoch_bin = af.pull_data_from_hdf5(
+#             sorted_dir, data_group_name, 'taste_select_neur_epoch_bin')[0]
+#     except:
+#         print("ERROR: No taste selective data.")
+#         quit()
 
-    bayes_dir_select_z = bayes_dir + 'Taste_Selective_ZScored/'
-    if os.path.isdir(bayes_dir_select_z) == False:
-        os.mkdir(bayes_dir_select_z)
+#     bayes_dir_select_z = bayes_dir + 'Taste_Selective_ZScored/'
+#     if os.path.isdir(bayes_dir_select_z) == False:
+#         os.mkdir(bayes_dir_select_z)
 
-    ddf.decode_epochs_zscore(tastant_fr_dist_z_pop, segment_spike_times, post_taste_dt,
-                             skip_dt, e_skip_dt, e_len_dt, dig_in_names, segment_times, bin_dt,
-                             segment_names, start_dig_in_times, taste_num_deliv,
-                             taste_select_neur_epoch_bin, use_full, max_hz_z_pop,
-                             bayes_dir_select_z, neuron_count_thresh, trial_start_frac,
-                             epochs_to_analyze, segments_to_analyze)
+#     ddf.decode_epochs_zscore(tastant_fr_dist_z_pop, segment_spike_times, post_taste_dt,
+#                              skip_dt, e_skip_dt, e_len_dt, dig_in_names, segment_times, bin_dt,
+#                              segment_names, start_dig_in_times, taste_num_deliv,
+#                              taste_select_neur_epoch_bin, use_full, max_hz_z_pop,
+#                              bayes_dir_select_z, neuron_count_thresh, trial_start_frac,
+#                              epochs_to_analyze, segments_to_analyze)
 
-    print("Plotting Results")
+#     print("Plotting Results")
 
-    df.plot_decoded(tastant_fr_dist_z_pop, num_tastes, num_neur, num_cp, segment_spike_times, tastant_spike_times,
-                    start_dig_in_times, end_dig_in_times, post_taste_dt, pre_taste_dt,
-					pop_taste_cp_raster_inds,
-                    e_skip_dt, e_len_dt, dig_in_names, segment_times,
-                    segment_names, taste_num_deliv, taste_select_neur_epoch_bin,
-                    use_full, bayes_dir_select_z, max_decode, max_hz_z_pop, seg_stat_bin,
-                    neuron_count_thresh, trial_start_frac,
-                    epochs_to_analyze, segments_to_analyze, bin_pre_taste, decode_prob_cutoff)
+#     df.plot_decoded(tastant_fr_dist_z_pop, num_tastes, num_neur, num_cp, segment_spike_times, tastant_spike_times,
+#                     start_dig_in_times, end_dig_in_times, post_taste_dt, pre_taste_dt,
+# 					pop_taste_cp_raster_inds,
+#                     e_skip_dt, e_len_dt, dig_in_names, segment_times,
+#                     segment_names, taste_num_deliv, taste_select_neur_epoch_bin,
+#                     use_full, bayes_dir_select_z, max_decode, max_hz_z_pop, seg_stat_bin,
+#                     neuron_count_thresh, trial_start_frac,
+#                     epochs_to_analyze, segments_to_analyze, bin_pre_taste, decode_prob_cutoff)
 
-    print("Plotting Results as a Function of Average Decoding Probability")
+#     print("Plotting Results as a Function of Average Decoding Probability")
 
-    df.plot_decoded_func_p(tastant_fr_dist_z_pop, num_tastes, num_neur, num_cp, segment_spike_times, tastant_spike_times,
-                           start_dig_in_times, end_dig_in_times, post_taste_dt, pop_taste_cp_raster_inds,
-                           e_skip_dt, e_len_dt, dig_in_names, segment_times,
-                           segment_names, taste_num_deliv, taste_select_epoch,
-                           use_full, bayes_dir_select_z, max_decode, max_hz_z_pop, seg_stat_bin,
-                           epochs_to_analyze, segments_to_analyze)
+#     df.plot_decoded_func_p(tastant_fr_dist_z_pop, num_tastes, num_neur, num_cp, segment_spike_times, tastant_spike_times,
+#                            start_dig_in_times, end_dig_in_times, post_taste_dt, pop_taste_cp_raster_inds,
+#                            e_skip_dt, e_len_dt, dig_in_names, segment_times,
+#                            segment_names, taste_num_deliv, taste_select_epoch,
+#                            use_full, bayes_dir_select_z, max_decode, max_hz_z_pop, seg_stat_bin,
+#                            epochs_to_analyze, segments_to_analyze)
 
-    print("Plotting Results as a Function of Co-Active Neurons")
+#     print("Plotting Results as a Function of Co-Active Neurons")
 
-    df.plot_decoded_func_n(tastant_fr_dist_z_pop, num_tastes, num_neur, num_cp, segment_spike_times, tastant_spike_times,
-                           start_dig_in_times, end_dig_in_times, post_taste_dt, pop_taste_cp_raster_inds,
-                           e_skip_dt, e_len_dt, dig_in_names, segment_times,
-                           segment_names, taste_num_deliv, taste_select_epoch,
-                           use_full, bayes_dir_select_z, max_decode, max_hz_z_pop, seg_stat_bin,
-                           epochs_to_analyze, segments_to_analyze)
+#     df.plot_decoded_func_n(tastant_fr_dist_z_pop, num_tastes, num_neur, num_cp, segment_spike_times, tastant_spike_times,
+#                            start_dig_in_times, end_dig_in_times, post_taste_dt, pop_taste_cp_raster_inds,
+#                            e_skip_dt, e_len_dt, dig_in_names, segment_times,
+#                            segment_names, taste_num_deliv, taste_select_epoch,
+#                            use_full, bayes_dir_select_z, max_decode, max_hz_z_pop, seg_stat_bin,
+#                            epochs_to_analyze, segments_to_analyze)

--- a/functions/analysis_funcs.py
+++ b/functions/analysis_funcs.py
@@ -97,7 +97,7 @@ def import_data(sorted_dir, segment_dir, data_save_dir):
 				dig_in_data = [list(dig_in_node[d_i][0][:]) for d_i in dig_in_ind]
 		except:
 			dig_in_data = [list(dig_in_node[d_i][:]) for d_i in dig_in_ind]
-		num_tastes = len(dig_in_ind)
+		num_tastes = len(dig_in_data)
 		del dig_in_node
 		#_____Convert dig_in_data to indices of dig_in start and end times_____
 		print("\tConverting digital inputs to free memory")
@@ -346,41 +346,42 @@ def taste_responsivity_raster(tastant_spike_times,start_dig_in_times,end_dig_in_
 	
 	return taste_responsivity_probability, taste_responsivity_binary
 
-def taste_cp_frs(taste_cp_raster_inds,tastant_spike_times,start_dig_in_times,end_dig_in_times,dig_in_names,num_neur,pre_taste_dt,post_taste_dt):
-	"""binned firing rates within epochs between given changepoints"""
-	
-	num_tastes = len(tastant_spike_times)
-	
-	num_cp = np.shape(taste_cp_raster_inds[0])[-1] - 1
-	for t_i in range(num_tastes-1):
-		if np.shape(taste_cp_raster_inds[t_i+1])[-1] - 1 < num_cp:
-			num_cp = np.shape(taste_cp_raster_inds[t_i+1])[-1] - 1
-	
-	tastant_binned_frs = [] #taste x neuron x delivery
-	for t_i in range(num_tastes):
-		num_deliv = len(tastant_spike_times[t_i])
-		t_cp_rast = taste_cp_raster_inds[t_i] #num_deliv x num_neur x num_cp+1
-		num_deliv, _, _ = np.shape(t_cp_rast)
-		deliv_binned_spikes = np.zeros((num_neur,num_deliv,num_cp))
-		for n_i in range(num_neur):
-			for d_i in range(num_deliv):
-				raster_times = tastant_spike_times[t_i][d_i][n_i]
-				start_taste_i = start_dig_in_times[t_i][d_i]
-				#times_pre_taste = (np.array(raster_times)[np.where(raster_times < start_taste_i)[0]] - (start_taste_i - pre_taste_dt)).astype('int')
-				#fr_avg_pre = (len(times_pre_taste)/pre_taste_dt)*(1000/1) #in hz
-				times_post_taste = (np.array(raster_times)[np.where((raster_times > start_taste_i)*(raster_times < start_taste_i + post_taste_dt))[0]] - start_taste_i).astype('int')
-				bin_post_taste = np.zeros(post_taste_dt)
-				bin_post_taste[times_post_taste] += 1
-				#Epoch-binned average firing rate
-				cp_bin_inds = t_cp_rast[d_i,n_i,:].astype('int')
-				post_taste_bins = np.zeros(num_cp)
-				for cp_i in range(num_cp):
-					if cp_bin_inds[cp_i+1]-cp_bin_inds[cp_i] != 0:
-						post_taste_bins[cp_i] = np.sum(bin_post_taste[cp_bin_inds[cp_i]:cp_bin_inds[cp_i+1]])/((cp_bin_inds[cp_i+1]-cp_bin_inds[cp_i])/1000)
-					else:
-						post_taste_bins[cp_i] = 0
-				deliv_binned_spikes[n_i,d_i,:] = post_taste_bins
-		tastant_binned_frs.append(deliv_binned_spikes)
-	
-	return tastant_binned_frs
+# def taste_cp_frs(taste_cp_raster_inds,tastant_spike_times,start_dig_in_times,end_dig_in_times,dig_in_names,num_neur,pre_taste_dt,post_taste_dt):
+# 	"""binned firing rates within epochs between given changepoints"""
+# 	
+# 	num_tastes = len(tastant_spike_times)
+# 	
+# 	num_cp = np.shape(taste_cp_raster_inds[0])[-1]
+# 	for t_i in range(num_tastes-1):
+# 		if np.shape(taste_cp_raster_inds[t_i+1])[-1] < num_cp:
+# 			num_cp = np.shape(taste_cp_raster_inds[t_i+1])[-1] - 1
+# 	
+# 	tastant_binned_frs = [] #taste x neuron x delivery
+# 	for t_i in range(num_tastes):
+# 		num_deliv = len(tastant_spike_times[t_i])
+# 		t_cp_rast = taste_cp_raster_inds[t_i] #num_deliv x num_neur x num_cp+1
+# 		num_deliv, _, _ = np.shape(t_cp_rast)
+# 		t_cp_rast_edit = np.concatenate((t_cp_rast,(post_taste_dt+pre_taste_dt)*np.ones((num_deliv,num_neur,1))),axis=-1)
+# 		deliv_binned_spikes = np.zeros((num_neur,num_deliv,num_cp))
+# 		for n_i in range(num_neur):
+# 			for d_i in range(num_deliv):
+# 				raster_times = tastant_spike_times[t_i][d_i][n_i]
+# 				start_taste_i = start_dig_in_times[t_i][d_i]
+# 				#times_pre_taste = (np.array(raster_times)[np.where(raster_times < start_taste_i)[0]] - (start_taste_i - pre_taste_dt)).astype('int')
+# 				#fr_avg_pre = (len(times_pre_taste)/pre_taste_dt)*(1000/1) #in hz
+# 				times_post_taste = (np.array(raster_times)[np.where((raster_times > start_taste_i)*(raster_times < start_taste_i + post_taste_dt))[0]] - start_taste_i).astype('int')
+# 				bin_post_taste = np.zeros(post_taste_dt)
+# 				bin_post_taste[times_post_taste] += 1
+# 				#Epoch-binned average firing rate
+# 				cp_bin_inds = t_cp_rast_edit[d_i,n_i,:].astype('int')
+# 				post_taste_bins = np.zeros(num_cp)
+# 				for cp_i in range(num_cp):
+# 					if cp_bin_inds[cp_i+1]-cp_bin_inds[cp_i] != 0:
+# 						post_taste_bins[cp_i] = np.sum(bin_post_taste[cp_bin_inds[cp_i]:cp_bin_inds[cp_i+1]])/((cp_bin_inds[cp_i+1]-cp_bin_inds[cp_i])/1000)
+# 					else:
+# 						post_taste_bins[cp_i] = 0
+# 				deliv_binned_spikes[n_i,d_i,:] = post_taste_bins
+# 		tastant_binned_frs.append(deliv_binned_spikes)
+# 	
+# 	return tastant_binned_frs
 	


### PR DESCRIPTION
- updated leave-one-out decoding to fill prior with data of different bin sizes from 50 ms up to the full epoch length
- parallelized leave-one-out decoding
- added new plots of decoded results / updated old plots
- added new statistics for not just full population of decoding but also neuron count cutoff and best event cutoff (neuron count, high decoding probability, highest correlation to expected taste)
- minor bug fixes