### PR TITLE
95 add a sweeping correlation calculation

### DIFF
--- a/functions/analysis_funcs.py
+++ b/functions/analysis_funcs.py
@@ -373,9 +373,9 @@ def get_bin_activity(segment_times_reshaped, segment_spike_times, bin_size,
         num_segments = len(segments_to_analyze)
     
     bin_times = []
-    bin_pop_fr = []
-    bin_fr_vecs = []
-    bin_fr_vecs_zscore = []
+    bin_pop_fr = dict()
+    bin_fr_vecs = dict()
+    bin_fr_vecs_zscore = dict()
     for s_i, s_ind in tqdm.tqdm(enumerate(segments_to_analyze)):
         seg_times = segment_times_reshaped[s_ind]
         seg_len = seg_times[1] - seg_times[0] + 1
@@ -400,9 +400,9 @@ def get_bin_activity(segment_times_reshaped, segment_spike_times, bin_size,
         seg_fr_vecs_z = list((np.array(seg_fr_vecs)-np.expand_dims(mean_fr,1))/np.expand_dims(std_fr,1))
         #Store
         bin_times.append(seg_times)
-        bin_pop_fr.append(seg_pop_fr)
-        bin_fr_vecs.append(seg_fr_vecs)
-        bin_fr_vecs_zscore.append(seg_fr_vecs_z)
+        bin_pop_fr[s_i] = seg_pop_fr
+        bin_fr_vecs[s_i] = seg_fr_vecs
+        bin_fr_vecs_zscore[s_i] = seg_fr_vecs_z
     
     return bin_times, bin_pop_fr, bin_fr_vecs, bin_fr_vecs_zscore
     

--- a/functions/analysis_funcs.py
+++ b/functions/analysis_funcs.py
@@ -358,3 +358,51 @@ def full_taste_interval_2way_anova(num_tastes, num_neur, tastant_spike_times,
         taste_fr_data.append(deliv_rasters)
 
     # Convert spike rasters to firing rate vectors
+
+def get_bin_activity(segment_times_reshaped, segment_spike_times, bin_size, 
+                     segments_to_analyze = [], no_z = False):
+    """Pull firing rate vectors (regular and z-scored) for sliding bins across 
+    rest intervals and return along with bin start times"""
+    
+    num_segments = len(segment_spike_times)
+    half_bin = np.ceil(bin_size/2).astype(int)
+
+    if len(segments_to_analyze) == 0:
+        segments_to_analyze = np.arange(num_segments)
+    else:
+        num_segments = len(segments_to_analyze)
+    
+    bin_times = []
+    bin_pop_fr = []
+    bin_fr_vecs = []
+    bin_fr_vecs_zscore = []
+    for s_i, s_ind in tqdm.tqdm(enumerate(segments_to_analyze)):
+        seg_times = segment_times_reshaped[s_ind]
+        seg_len = seg_times[1] - seg_times[0] + 1
+        seg_st = segment_spike_times[s_ind] 
+        num_neur = len(seg_st)
+        #Pull binary raster of segment
+        bin_spike_storage = np.zeros((num_neur,seg_len))
+        for n_i in range(num_neur):
+            neur_st = (np.array(seg_st[n_i]) - seg_times[0]).astype('int')
+            bin_spike_storage[n_i,neur_st] = 1
+        del neur_st, seg_st
+        #Grab neuron firing rates across bins in segment
+        seg_fr_vecs = []
+        seg_pop_fr = []
+        seg_bin_times = np.arange(half_bin,seg_len-half_bin)
+        for st_i, st_ind in enumerate(seg_bin_times):
+            seg_fr_vecs.append(list(np.sum(bin_spike_storage[:,st_ind-half_bin:st_ind+half_bin],axis=1)/(2*half_bin/1000))) #In Hz
+            seg_pop_fr.extend([np.sum(bin_spike_storage[:,st_ind-half_bin:st_ind+half_bin])/(2*half_bin/1000)/num_neur]) #In Hz
+        #Calculate z-scored fr vecs
+        mean_fr = np.mean(np.array(seg_fr_vecs),1)
+        std_fr = np.std(np.array(seg_fr_vecs),1)
+        seg_fr_vecs_z = list((np.array(seg_fr_vecs)-np.expand_dims(mean_fr,1))/np.expand_dims(std_fr,1))
+        #Store
+        bin_times.append(seg_times)
+        bin_pop_fr.append(seg_pop_fr)
+        bin_fr_vecs.append(seg_fr_vecs)
+        bin_fr_vecs_zscore.append(seg_fr_vecs_z)
+    
+    return bin_times, bin_pop_fr, bin_fr_vecs, bin_fr_vecs_zscore
+    

--- a/functions/dev_funcs.py
+++ b/functions/dev_funcs.py
@@ -296,8 +296,9 @@ def calculate_vec_correlations(num_neur, segment_dev_vectors, tastant_spike_time
             try:
                 neuron_pop_vec_corr_storage = np.load(filename_pop_vec)
                 filename_pop_vec_loaded = 1
+                print("\t\t\tVector correlations previously calculated for taste " + str(t_i+1))
             except:
-                print("\t\t\tVector correlations not calculated for taste " + str(t_i))
+                print("\t\t\tVector correlations now being calculated for taste " + str(t_i+1))
             if filename_pop_vec_loaded == 0:
                 taste_cp_pop = cp[t_i]
                 # Note, num_cp = num_cp+1 with the first value the taste delivery index
@@ -520,16 +521,16 @@ def calculate_vec_correlations_zscore(num_neur, z_bin, segment_dev_vecs_zscore, 
         dev_fr_vecs = np.array(seg_vecs)
         for t_i in range(num_tastes):  # Loop through each taste
             # Set storage directory and check if data previously stored
-            filename_pop_vec = save_dir + \
-                segment_names[s_i] + '_' + dig_in_names[t_i] + '_pop_vec.npy'
+            filename_pop_vec = os.path.join(save_dir, segment_names[s_i] + '_' 
+                                            + dig_in_names[t_i] + '_pop_vec.npy')
             filename_pop_vec_loaded = 0
             try:
                 neuron_pop_vec_corr_storage = np.load(filename_pop_vec)
                 filename_pop_vec_loaded = 1
+                print("\t\t\tVector correlations previously calculated for taste " + str(t_i + 1))
             except:
-                print("\t\t\tVector correlations not calculated for taste " + str(t_i))
+                print("\t\t\tVector correlations now being calculated for taste " + str(t_i + 1))
             if filename_pop_vec_loaded == 0:
-                print("\t\t\tCalculating Taste #" + str(t_i + 1))
                 taste_cp_pop = cp[t_i]
                 taste_spikes = tastant_spike_times[t_i]
                 # Note, num_cp = num_cp+1 with the first value the taste delivery index

--- a/functions/dev_funcs.py
+++ b/functions/dev_funcs.py
@@ -291,8 +291,7 @@ def calculate_vec_correlations(num_neur, segment_dev_vectors, tastant_spike_time
 
         for t_i in range(num_tastes):  # Loop through each taste
             # Set storage directory and check if data previously stored
-            filename_pop_vec = save_dir + \
-                segment_names[s_i] + '_' + dig_in_names[t_i] + '_pop_vec.npy'
+            filename_pop_vec = os.path.join(save_dir, segment_names[s_i] + '_' + dig_in_names[t_i] + '_pop_vec.npy')
             filename_pop_vec_loaded = 0
             try:
                 neuron_pop_vec_corr_storage = np.load(filename_pop_vec)
@@ -586,7 +585,8 @@ def calculate_vec_correlations_zscore(num_neur, z_bin, segment_dev_vecs_zscore, 
                 np.save(filename_pop_vec, neuron_pop_vec_corr_storage)
 
 
-def pull_corr_dev_stats(segment_names, dig_in_names, save_dir, segments_to_analyze=[]):
+def pull_corr_dev_stats(segment_names, dig_in_names, save_dir, segments_to_analyze=[],
+                        dev = True):
     """For each epoch and each segment pull out the top 10 most correlated deviation 
     bins and plot side-by-side with the epoch they are correlated with"""
 
@@ -602,15 +602,16 @@ def pull_corr_dev_stats(segment_names, dig_in_names, save_dir, segments_to_analy
         seg_name = segment_names[s_i]
         for t_i in range(num_tastes):  # Loop through each taste
             # Import distance numpy array
-            filename_pop_vec = save_dir + \
-                segment_names[s_i] + '_' + dig_in_names[t_i] + '_pop_vec.npy'
+            filename_pop_vec = os.path.join(save_dir, segment_names[s_i] + '_' 
+                                            + dig_in_names[t_i] + '_pop_vec.npy')
             population_vec_data_storage = np.load(filename_pop_vec)
             # Calculate statistics
             data_dict = dict()
             data_dict['segment'] = seg_name
             data_dict['taste'] = dig_in_names[t_i]
-            num_dev, num_deliv, num_cp = np.shape(population_vec_data_storage)
-            data_dict['num_dev'] = num_dev
+            if dev == True:
+                num_dev, num_deliv, num_cp = np.shape(population_vec_data_storage)
+                data_dict['num_dev'] = num_dev
             data_dict['pop_vec_data_storage'] = np.abs(
                 population_vec_data_storage)
             segment_stats[t_i] = data_dict

--- a/functions/run_analysis_handler.py
+++ b/functions/run_analysis_handler.py
@@ -21,9 +21,8 @@ from functions.deviation_null_analysis import run_deviation_null_analysis
 from functions.deviation_analysis import run_find_deviations
 from functions.changepoint_analysis import run_changepoint_detection
 from functions.data_description_analysis import run_data_description_analysis
+from functions.sliding_correlations import run_sliding_correlations
 from utils.replay_utils import state_tracker
-
-
 
 class run_analysis_steps():
 
@@ -93,9 +92,13 @@ class run_analysis_steps():
         state_exec_dict[4]['name'] = 'Deviation x Taste Correlations'
         state_exec_dict[4]['exec'] = 'run_deviation_correlations([self.metadata,self.data_dict])'
         state_exec_dict[5] = dict()
-        state_exec_dict[5]['name'] = 'Bayesian Replay Decoding'
-        state_exec_dict[5]['exec'] = 'run_dependent_bayes([self.metadata,self.data_dict])'
-        state_exec_dict[6] = dict()
-        state_exec_dict[6]['name'] = 'Bayesian Deviation Decoding'
-        state_exec_dict[6]['exec'] = ''
+        state_exec_dict[5]['name'] = 'Sliding Bin Correlations'
+        state_exec_dict[5]['exec'] = 'run_sliding_correlations([self.metadata,self.data_dict])'
+        
+        #state_exec_dict[6] = dict()
+        #state_exec_dict[6]['name'] = 'Bayesian Replay Decoding'
+        #state_exec_dict[6]['exec'] = 'run_dependent_bayes([self.metadata,self.data_dict])'
+        #state_exec_dict[7] = dict()
+        #state_exec_dict[7]['name'] = 'Bayesian Deviation Decoding'
+        #state_exec_dict[7]['exec'] = ''
         self.state_exec_dict = state_exec_dict

--- a/functions/slide_plot_funcs.py
+++ b/functions/slide_plot_funcs.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Created on Fri Jul 12 09:43:21 2024
+
+@author: Hannah Germaine
+
+A collection of function dedicated to analyzing and plotting the results of a
+sliding bin correlation analysis of rest intervals.
+"""
+
+import os
+import itertools
+import tqdm
+import numpy as np
+import matplotlib.pyplot as plt
+from scipy.stats import pearsonr, ttest_ind
+
+def slide_corr_vs_rate(corr_slide_stats,bin_times,bin_pop_fr,num_cp,plot_dir,save_dir,
+                       segment_names,dig_in_names,segments_to_analyze=[]):
+    """Calculate and plot the correlation between sliding bin correlation 
+    calculations and the population rate"""
+    
+    num_tastes = len(dig_in_names)
+    if len(segments_to_analyze) == 0:
+        segments_to_analyze = np.arange(len(segment_names))
+    num_segments = len(segments_to_analyze)
+    
+    max_corr_val = 0
+    min_corr_val = 0
+    if os.path.isfile(os.path.join(save_dir,'popfr_corr_storage.npy')):
+        popfr_corr_storage = np.load(os.path.join(save_dir,'popfr_corr_storage.npy'),allow_pickle=True).item()
+        #Plot
+        f, ax = plt.subplots(nrows = num_segments, ncols = num_tastes, figsize = (4*num_tastes,4*num_segments))
+        for s_i, s_ind in tqdm.tqdm(enumerate(segments_to_analyze)):
+            seg_name = segment_names[s_ind]
+            for t_i in range(num_tastes):
+                taste_name = dig_in_names[t_i]
+                popfr_corr_vals = popfr_corr_storage[seg_name][taste_name]
+                if np.min(popfr_corr_vals) < min_corr_val:
+                    min_corr_val = np.min(popfr_corr_vals)
+                if np.max(popfr_corr_vals) > max_corr_val:
+                    max_corr_val = np.max(popfr_corr_vals)
+                #Plot correlation across time
+                #mean_corr_by_changepoint = np.nanmean(popfr_corr_vals,0)
+                #std_corr_by_changepoint = np.nanstd(popfr_corr_vals,0)
+                #ax[s_i,t_i].plot(np.arange(num_cp),mean_corr_by_changepoint)
+                #ax[s_i,t_i].fill_between(np.arange(num_cp),mean_corr_by_changepoint-std_corr_by_changepoint,mean_corr_by_changepoint+std_corr_by_changepoint,alpha=0.3)
+                for cp_i in range(num_cp):
+                    corr_dataset = popfr_corr_vals[:,cp_i]
+                    ax[s_i,t_i].violinplot(list(corr_dataset[~np.isnan(corr_dataset)]),[cp_i],showmeans=True)
+                ax[s_i,t_i].set_title(seg_name + ' x ' + taste_name)
+                ax[s_i,t_i].set_ylabel('Pearson Correlation')
+                ax[s_i,t_i].set_xlabel('Epoch')
+        for s_i in range(len(segments_to_analyze)):
+            for t_i in range(num_tastes):
+                ax[s_i,t_i].set_ylim([min_corr_val + 0.1*min_corr_val,max_corr_val + 0.1*max_corr_val])
+        #Finish figure and save
+        plt.suptitle('Population Rate x Bin Correlation')
+        plt.tight_layout()
+        f.savefig(os.path.join(plot_dir,'pop_rate_x_bin_corr_epochs.png'))
+        f.savefig(os.path.join(plot_dir,'pop_rate_x_bin_corr_epochs.svg'))
+        plt.close(f)
+    else:
+        #Plot for each taste and segment the correlation by epoch
+        f, ax = plt.subplots(nrows = num_segments, ncols = num_tastes, figsize = (4*num_tastes,4*num_segments))
+        popfr_corr_storage = dict()
+        for s_i, s_ind in tqdm.tqdm(enumerate(segments_to_analyze)):
+            seg_name = segment_names[s_ind]
+            seg_pop_fr = np.array(bin_pop_fr[s_i])
+            popfr_corr_storage[seg_name] = dict()
+            for t_i in range(num_tastes):
+                taste_name = dig_in_names[t_i]
+                st_corr = corr_slide_stats[seg_name][t_i]['pop_vec_data_storage']
+                num_times, num_deliv, _ = np.shape(st_corr)
+                #Calculate correlation between population fr and correlations to taste
+                popfr_corr_vals = np.zeros((num_deliv,num_cp))
+                popfr_inf_inds = np.where(np.isinf(seg_pop_fr))[0]
+                popfr_nan_inds = np.where(np.isnan(seg_pop_fr))[0]
+                for d_i in range(num_deliv):
+                    for cp_i in range(num_cp):
+                        cp_corr_data = np.array(st_corr[:,d_i,cp_i]).squeeze()
+                        cp_inf_inds = np.where(np.isinf(cp_corr_data))[0]
+                        cp_nan_inds = np.where(np.isnan(cp_corr_data))[0]
+                        remaining_inds = np.setdiff1d(np.arange(len(seg_pop_fr)),np.concatenate((popfr_inf_inds,popfr_nan_inds,cp_inf_inds,cp_nan_inds)))
+                        #Pearson corr calc
+                        # cp_corr_mean = np.nanmean(cp_corr_data)
+                        # popfr_mean = np.nanmean(seg_pop_fr)
+                        # numerator = np.nansum((cp_corr_data - cp_corr_mean)*(seg_pop_fr - popfr_mean))
+                        # denominator = np.sqrt(np.nansum((cp_corr_data - cp_corr_mean)**2)*np.nansum((seg_pop_fr - popfr_mean)**2))
+                        # popfr_corr_vals[d_i,cp_i] = numerator/denominator
+                        if len(remaining_inds) > 2:
+                            corr_result = pearsonr(cp_corr_data[remaining_inds],seg_pop_fr[remaining_inds],alternative='two-sided')[0]
+                        else:
+                            corr_result = np.nan
+                        popfr_corr_vals[d_i,cp_i] = corr_result
+                popfr_corr_storage[seg_name][taste_name] = popfr_corr_vals
+                if np.min(popfr_corr_vals) < min_corr_val:
+                    min_corr_val = np.min(popfr_corr_vals)
+                if np.max(popfr_corr_vals) > max_corr_val:
+                    max_corr_val = np.max(popfr_corr_vals)
+                for cp_i in range(num_cp):
+                    corr_dataset = popfr_corr_vals[:,cp_i]
+                    ax[s_i,t_i].violinplot(list(corr_dataset[~np.isnan(corr_dataset)]),[cp_i],showmeans=True)
+                ax[s_i,t_i].set_title(seg_name + ' x ' + taste_name)
+                ax[s_i,t_i].set_ylabel('Pearson Correlation')
+                ax[s_i,t_i].set_xlabel('Epoch')
+        for s_i in range(len(segments_to_analyze)):
+            for t_i in range(num_tastes):
+                ax[s_i,t_i].set_ylim([min_corr_val + 0.1*min_corr_val,max_corr_val + 0.1*max_corr_val])
+        #Finish figure and save
+        plt.suptitle('Population Rate x Bin Correlation')
+        plt.tight_layout()
+        f.savefig(os.path.join(plot_dir,'pop_rate_x_bin_corr_epochs.png'))
+        f.savefig(os.path.join(plot_dir,'pop_rate_x_bin_corr_epochs.svg'))
+        plt.close(f)
+        #Save dictionary
+        np.save(os.path.join(save_dir,'popfr_corr_storage.npy'),popfr_corr_storage,True)
+
+    #Plot for each epoch and segment the correlation by taste
+    f, ax = plt.subplots(nrows = num_segments, ncols = num_cp, figsize = (4*num_tastes,4*num_segments))
+    for s_i, s_ind in tqdm.tqdm(enumerate(segments_to_analyze)):
+        seg_name = segment_names[s_ind]
+        seg_pop_fr = np.array(bin_pop_fr[s_i])
+        for cp_i in range(num_cp):
+            #Plot individual taste distributions
+            for t_i in range(num_tastes):
+                taste_name = dig_in_names[t_i]
+                st_corr = corr_slide_stats[seg_name][t_i]['pop_vec_data_storage']
+                num_times, num_deliv, num_cp = np.shape(st_corr)
+                popfr_corr_vals = popfr_corr_storage[seg_name][taste_name][:,cp_i].squeeze()
+                ax[s_i,cp_i].boxplot(popfr_corr_vals[~np.isnan(popfr_corr_vals)],positions = [t_i+1])
+                #Calculate if distribution is significantly above 0
+                fifth_percentile = np.percentile(popfr_corr_vals[~np.isnan(popfr_corr_vals)],5)
+                if 0 < fifth_percentile:
+                    ax[s_i,cp_i].scatter(t_i,max_corr_val,marker='*',color='k',s=5)
+            #Plot pairwise significances
+            taste_pairs = list(itertools.combinations(np.arange(num_tastes), 2))
+            sig_max_corr_val = max_corr_val
+            for tp_i in range(len(taste_pairs)):
+                t_0 = taste_pairs[tp_i][0]
+                t_0_name = dig_in_names[t_0]
+                t_1 = taste_pairs[tp_i][1]
+                t_1_name = dig_in_names[t_1]
+                t_0_corr_vals = popfr_corr_storage[seg_name][t_0_name][:,cp_i].squeeze()
+                t_1_corr_vals = popfr_corr_storage[seg_name][t_1_name][:,cp_i].squeeze()
+                stat = ttest_ind(t_0_corr_vals[~np.isnan(t_0_corr_vals)],t_1_corr_vals[~np.isnan(t_1_corr_vals)])
+                if stat[1] < 0.05:
+                    sig_max_corr_val = sig_max_corr_val + 0.05*sig_max_corr_val
+                    ax[s_i,cp_i].plot([t_0+1,t_1+1],[sig_max_corr_val,sig_max_corr_val])
+                    sig_max_corr_val = sig_max_corr_val + 0.05*sig_max_corr_val
+                    ax[s_i,cp_i].scatter(t_0+1 + (t_1-t_0)/2,sig_max_corr_val,marker='*',color='k')
+            ax[s_i,cp_i].set_title(seg_name + ' x Epoch ' + str(cp_i))
+            ax[s_i,cp_i].set_xticklabels(dig_in_names)
+            ax[s_i,cp_i].set_ylabel('Pearson Correlations')
+            ax[s_i,cp_i].set_xlabel('Taste')
+            ax[s_i,cp_i].set_ylim([min_corr_val + 0.2*min_corr_val,max_corr_val + 0.2*max_corr_val])
+            ax[s_i,cp_i].set_ylim([min_corr_val + 0.2*min_corr_val,max_corr_val + 0.2*max_corr_val])
+    #Finish figure and save
+    plt.suptitle('Population Rate x Bin Correlation')
+    plt.tight_layout()
+    f.savefig(os.path.join(plot_dir,'pop_rate_x_bin_corr_tastes.png'))
+    f.savefig(os.path.join(plot_dir,'pop_rate_x_bin_corr_tastes.svg'))
+    plt.close(f)
+    
+    #Plot the distribution means on the same axes as trends but by taste
+    min_mean = 0
+    max_mean = 0
+    f, ax = plt.subplots(ncols=num_tastes,figsize=(4*num_tastes,4))
+    for s_i, s_ind in tqdm.tqdm(enumerate(segments_to_analyze)):
+        seg_name = segment_names[s_ind]
+        seg_pop_fr = np.array(bin_pop_fr[s_i])
+        for t_i in range(num_tastes):
+            taste_name = dig_in_names[t_i]
+            popfr_corr_vals = popfr_corr_storage[seg_name][taste_name] #num_deliv x num_cp
+            mean_vals = np.nanmean(popfr_corr_vals,0)
+            if np.min(mean_vals) < min_mean:
+                min_mean = np.min(mean_vals)
+            if np.max(mean_vals) > max_mean:
+                max_mean = np.max(mean_vals)
+            ax[t_i].plot(np.arange(num_cp),mean_vals,label=seg_name)
+    for t_i in range(num_tastes):
+        ax[t_i].legend(loc='upper left')
+        ax[t_i].axhline(0,alpha=0.2,linestyle='dashed',color='k')
+        ax[t_i].set_ylim([min_mean - np.abs(0.1*min_mean), max_mean + 0.1*max_mean])
+        ax[t_i].set_xticks(np.arange(num_cp))
+        ax[t_i].set_xlabel('Epoch Index')
+        ax[t_i].set_ylabel('Mean Pearson Correlation')
+        ax[t_i].set_title(dig_in_names[t_i])
+    plt.suptitle('Mean Correlation of Population Rate to Bin Taste Correlation')
+    plt.tight_layout()
+    f.savefig(os.path.join(plot_dir,'mean_pop_rate_x_bin_corr_tastes.png'))
+    f.savefig(os.path.join(plot_dir,'mean_pop_rate_x_bin_corr_tastes.svg'))
+    plt.close(f)
+    
+    return popfr_corr_storage
+
+def top_corr_rate_dist(corr_slide_stats,bin_times,bin_pop_fr,num_cp,plot_dir,
+                       segment_names,dig_in_names,segments_to_analyze=[]):
+    """This function pulls out the top 90th+ percentile of correlation value 
+    bins across segments and looks at the population firing rate distribution.
+    
+    INPUTS:
+        - 
+    OUTPUTS:
+        - 
+    
+    """
+    
+    num_tastes = len(dig_in_names)
+    if len(segments_to_analyze) == 0:
+        segments_to_analyze = np.arange(len(segment_names))
+    num_segments = len(segments_to_analyze)
+    
+    for s_i, s_ind in tqdm.tqdm(enumerate(segments_to_analyze)):
+        seg_name = segment_names[s_ind]
+        seg_pop_fr = np.array(bin_pop_fr[s_i])
+        popfr_corr_storage[seg_name] = dict()
+        for t_i in range(num_tastes):
+            taste_name = dig_in_names[t_i]
+            st_corr = corr_slide_stats[seg_name][t_i]['pop_vec_data_storage']
+            num_times, num_deliv, _ = np.shape(st_corr)
+            
+            
+

--- a/functions/sliding_correlations.py
+++ b/functions/sliding_correlations.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Created on Wed Jul 10 14:22:00 2024
+
+@author: Hannah Germaine
+
+This code runs an analysis of sliding bins and their correlations to taste 
+responses.
+"""
+
+import os
+
+current_path = os.path.realpath(__file__)
+blech_codes_path = '/'.join(current_path.split('/')[:-1]) + '/'
+os.chdir(blech_codes_path)
+
+import functions.analysis_funcs as af
+import functions.dev_funcs as df
+import functions.hdf5_handling as hf5
+import functions.dev_plot_funcs as dpf
+import functions.slide_plot_funcs as spf
+
+class run_sliding_correlations():
+    
+    def __init__(self, args):
+        self.metadata = args[0]
+        self.data_dict = args[1]
+        self.gather_variables()
+        
+        
+    def gather_variables(self,):
+        # Directories
+        self.slide_dir = self.metadata['dir_name'] + 'Sliding_Correlations/'
+        if os.path.isdir(self.slide_dir) == False:
+            os.mkdir(self.slide_dir)
+        self.hdf5_dir = self.metadata['hdf5_dir']
+        # Params/Variables
+        self.num_neur = self.data_dict['num_neur']
+        self.pre_taste = self.metadata['params_dict']['pre_taste']
+        self.post_taste = self.metadata['params_dict']['post_taste']
+        self.segments_to_analyze = self.metadata['params_dict']['segments_to_analyze']
+        self.epochs_to_analyze = self.metadata['params_dict']['epochs_to_analyze']
+        self.segment_names = self.data_dict['segment_names']
+        self.num_segments = len(self.segment_names)
+        self.segment_spike_times = self.data_dict['segment_spike_times']
+        self.segment_times = self.data_dict['segment_times']
+        self.segment_times_reshaped = [
+            [self.segment_times[i], self.segment_times[i+1]] for i in range(self.num_segments)]
+        # Remember this is 1 less than the number of epochs
+        self.num_cp = self.metadata['params_dict']['num_cp'] + 1
+        self.tastant_spike_times = self.data_dict['tastant_spike_times']
+        self.start_dig_in_times = self.data_dict['start_dig_in_times']
+        self.end_dig_in_times = self.data_dict['end_dig_in_times']
+        self.dig_in_names = self.data_dict['dig_in_names']
+        self.bin_size = self.metadata['params_dict']['min_dev_size'] #Use the same minimal size as deviation events
+        self.z_bin = self.metadata['params_dict']['z_bin']
+        data_group_name = 'changepoint_data'
+        self.pop_taste_cp_raster_inds = hf5.pull_data_from_hdf5(
+            self.hdf5_dir, data_group_name, 'pop_taste_cp_raster_inds')
+        data_group_name = 'taste_discriminability'
+        self.discrim_neur = np.squeeze(hf5.pull_data_from_hdf5(
+            self.hdf5_dir, data_group_name, 'discrim_neur'))
+       
+        
+    def calculate_bin_data(self,):
+        print("\tNow calculating binned activity")
+        bin_times, bin_pop_fr, bin_fr_vecs, bin_fr_vecs_zscore = af.get_bin_activity(self.segment_times_reshaped,
+                                                                    self.segment_spike_times, self.bin_size, 
+                                                                    self.segments_to_analyze, False)
+        self.bin_times = bin_times
+        self.bin_pop_fr = bin_pop_fr
+        self.bin_fr_vecs = bin_fr_vecs
+        self.bin_fr_vecs_zscore = bin_fr_vecs_zscore
+        
+    def calculate_correlations_all(self,):
+        self.corr_dir = os.path.join(self.slide_dir,'all_neur')
+        if os.path.isdir(self.corr_dir) == False:
+            os.mkdir(self.corr_dir)
+        
+        neuron_keep_indices = np.ones(np.shape(self.discrim_neur))
+        
+        df.calculate_vec_correlations(self.num_neur, self.bin_fr_vecs, self.tastant_spike_times,
+                                      self.start_dig_in_times, self.end_dig_in_times, self.segment_names,
+                                      self.dig_in_names, self.pre_taste, self.post_taste, self.pop_taste_cp_raster_inds,
+                                      self.corr_dir, self.neuron_keep_indices, self.segments_to_analyze)  # For all neurons in dataset
+        
+        
+    def calculate_correlations_zscore(self,):
+        
+        
+    def generate_distribution_plots(self,):
+        """Generate cumulative and density distribution plots of the 
+        correlation distributions"""
+        # Plot dir setup
+        plot_dir = os.path.join(self.corr_dir,'plots/')
+        if os.path.isdir(plot_dir) == False:
+            os.mkdir(plot_dir)
+        self.plot_dir = plot_dir
+        # Pull statistics into dictionary and plot
+        corr_slide_stats = df.pull_corr_dev_stats(
+            self.segment_names, self.dig_in_names, self.current_corr_dir, 
+            self.segments_to_analyze, False)
+        print("\tPlotting Correlation Statistics")
+        dpf.plot_stats(corr_slide_stats, self.segment_names, self.dig_in_names, self.plot_dir,
+                       'Correlation', self.neuron_keep_indices, self.segments_to_analyze)
+        segment_pop_vec_data = dpf.plot_combined_stats(corr_dev_stats, self.segment_names, self.dig_in_names,
+                                                       self.plot_dir, 'Correlation', self.neuron_keep_indices, self.segments_to_analyze)
+        self.segment_pop_vec_data = segment_pop_vec_data
+        
+    
+    def calculate_corr_to_pop_rate(self,):
+        """Calculate how correlated bin correlations to taste are with the 
+        population firing rate in that bin"""
+        # 
+        
+    def calculate_dev_overlap(self,):
+        """Calculate how highly-correlated bins overlap with calculated 
+        deviation events"""
+    
+    

--- a/functions/sliding_correlations.py
+++ b/functions/sliding_correlations.py
@@ -15,6 +15,7 @@ current_path = os.path.realpath(__file__)
 blech_codes_path = '/'.join(current_path.split('/')[:-1]) + '/'
 os.chdir(blech_codes_path)
 
+import numpy as np
 import functions.analysis_funcs as af
 import functions.dev_funcs as df
 import functions.hdf5_handling as hf5
@@ -27,7 +28,9 @@ class run_sliding_correlations():
         self.metadata = args[0]
         self.data_dict = args[1]
         self.gather_variables()
-        
+        self.calculate_bin_data()
+        self.calculate_correlations_all()
+        self.calculate_correlations_zscore()
         
     def gather_variables(self,):
         # Directories
@@ -79,15 +82,33 @@ class run_sliding_correlations():
             os.mkdir(self.corr_dir)
         
         neuron_keep_indices = np.ones(np.shape(self.discrim_neur))
+        self.neuron_keep_indices = neuron_keep_indices
         
         df.calculate_vec_correlations(self.num_neur, self.bin_fr_vecs, self.tastant_spike_times,
                                       self.start_dig_in_times, self.end_dig_in_times, self.segment_names,
                                       self.dig_in_names, self.pre_taste, self.post_taste, self.pop_taste_cp_raster_inds,
                                       self.corr_dir, self.neuron_keep_indices, self.segments_to_analyze)  # For all neurons in dataset
         
+        #Create plots
+        self.generate_distribution_plots()
+        self.calculate_corr_to_pop_rate()
         
     def calculate_correlations_zscore(self,):
+        self.corr_dir = os.path.join(self.slide_dir,'all_neur_zscore')
+        if os.path.isdir(self.corr_dir) == False:
+            os.mkdir(self.corr_dir)
+            
+        neuron_keep_indices = np.ones(np.shape(self.discrim_neur))
+        self.neuron_keep_indices = neuron_keep_indices
         
+        df.calculate_vec_correlations_zscore(self.num_neur, self.z_bin, self.bin_fr_vecs_zscore, self.tastant_spike_times,
+                                             self.segment_times, self.segment_spike_times, self.start_dig_in_times, self.end_dig_in_times,
+                                             self.segment_names, self.dig_in_names, self.pre_taste, self.post_taste, self.pop_taste_cp_raster_inds,
+                                             self.corr_dir, self.neuron_keep_indices, self.segments_to_analyze)
+        
+        #Create plots
+        self.generate_distribution_plots()
+        self.calculate_corr_to_pop_rate()
         
     def generate_distribution_plots(self,):
         """Generate cumulative and density distribution plots of the 
@@ -99,12 +120,13 @@ class run_sliding_correlations():
         self.plot_dir = plot_dir
         # Pull statistics into dictionary and plot
         corr_slide_stats = df.pull_corr_dev_stats(
-            self.segment_names, self.dig_in_names, self.current_corr_dir, 
+            self.segment_names, self.dig_in_names, self.corr_dir, 
             self.segments_to_analyze, False)
+        self.corr_slide_stats = corr_slide_stats
         print("\tPlotting Correlation Statistics")
         dpf.plot_stats(corr_slide_stats, self.segment_names, self.dig_in_names, self.plot_dir,
                        'Correlation', self.neuron_keep_indices, self.segments_to_analyze)
-        segment_pop_vec_data = dpf.plot_combined_stats(corr_dev_stats, self.segment_names, self.dig_in_names,
+        segment_pop_vec_data = dpf.plot_combined_stats(corr_slide_stats, self.segment_names, self.dig_in_names,
                                                        self.plot_dir, 'Correlation', self.neuron_keep_indices, self.segments_to_analyze)
         self.segment_pop_vec_data = segment_pop_vec_data
         
@@ -112,8 +134,17 @@ class run_sliding_correlations():
     def calculate_corr_to_pop_rate(self,):
         """Calculate how correlated bin correlations to taste are with the 
         population firing rate in that bin"""
-        # 
-        
+        #Correlation calculations and plots
+        spf.slide_corr_vs_rate(self.corr_slide_stats,self.bin_times,self.bin_pop_fr,
+                               self.num_cp,self.plot_dir,self.corr_dir,
+                               self.segment_names,self.dig_in_names,
+                               self.segments_to_analyze)
+        #90th-Percentile Correlations and the related pop rates
+        spf.top_corr_rate_dist(self.corr_slide_stats,self.bin_times,self.bin_pop_fr,
+                               self.num_cp,self.plot_dir,self.corr_dir,
+                               self.segment_names,self.dig_in_names,
+                               self.segments_to_analyze)
+
     def calculate_dev_overlap(self,):
         """Calculate how highly-correlated bins overlap with calculated 
         deviation events"""

--- a/utils/test_support.py
+++ b/utils/test_support.py
@@ -63,321 +63,70 @@ tastant_spike_times = af.calc_tastant_spike_times(data_dict['segment_times'],dat
 data_dict['segment_spike_times'] = segment_spike_times
 data_dict['tastant_spike_times'] = tastant_spike_times
 
-#%% Decoding support
+#%% Sweeping Corr Support
 
-#Directories
+import functions.analysis_funcs as af
+import functions.dev_funcs as df
+import functions.hdf5_handling as hf5
+import functions.dev_plot_funcs as dpf
+import functions.slide_plot_funcs as spf
+
+# Directories
+slide_dir = metadata['dir_name'] + 'Sliding_Correlations/'
+if os.path.isdir(slide_dir) == False:
+    os.mkdir(slide_dir)
 hdf5_dir = metadata['hdf5_dir']
-bayes_dir = metadata['dir_name'] + 'Bayes_Dependent_Decoding/'
-if os.path.isdir(bayes_dir) == False:
-	os.mkdir(bayes_dir)
-#General Params/Variables
+# Params/Variables
 num_neur = data_dict['num_neur']
 pre_taste = metadata['params_dict']['pre_taste']
 post_taste = metadata['params_dict']['post_taste']
-pre_taste_dt = np.ceil(pre_taste*1000).astype('int')
-post_taste_dt = np.ceil(post_taste*1000).astype('int')
 segments_to_analyze = metadata['params_dict']['segments_to_analyze']
 epochs_to_analyze = metadata['params_dict']['epochs_to_analyze']
 segment_names = data_dict['segment_names']
 num_segments = len(segment_names)
 segment_spike_times = data_dict['segment_spike_times']
-segment_times = data_dict['segment_times']
-segment_times_reshaped = [[segment_times[i],segment_times[i+1]] for i in range(num_segments)]
-num_cp = metadata['params_dict']['num_cp'] + 1 #Remember this imported value is 1 less than the number of epochs
-tastant_spike_times = data_dict['tastant_spike_times']
-start_dig_in_times = data_dict['start_dig_in_times']
-end_dig_in_times = data_dict['end_dig_in_times']
-dig_in_names = data_dict['dig_in_names']
-num_tastes = len(dig_in_names)
-fr_bins = metadata['params_dict']['fr_bins']
-#Bayes Params/Variables
-skip_time = metadata['params_dict']['bayes_params']['skip_time']
-skip_dt = np.ceil(skip_time*1000).astype('int')
-e_skip_time = metadata['params_dict']['bayes_params']['e_skip_time']
-e_skip_dt = np.ceil(e_skip_time*1000).astype('int')
-e_len_time = metadata['params_dict']['bayes_params']['e_len_time']
-e_len_dt = np.ceil(e_len_time*1000).astype('int')
-neuron_count_thresh = metadata['params_dict']['bayes_params']['neuron_count_thresh']
-max_decode = metadata['params_dict']['bayes_params']['max_decode']
-seg_stat_bin = metadata['params_dict']['bayes_params']['seg_stat_bin']
-trial_start_frac = metadata['params_dict']['bayes_params']['trial_start_frac']
-decode_prob_cutoff = metadata['params_dict']['bayes_params']['decode_prob_cutoff']
-bin_time = metadata['params_dict']['bayes_params']['bin_time']
-bin_dt = np.ceil(bin_time*1000).astype('int')
-#Import changepoint data
-pop_taste_cp_raster_inds = hf5.pull_data_from_hdf5(hdf5_dir,'changepoint_data','pop_taste_cp_raster_inds')
-pop_taste_cp_raster_inds = pop_taste_cp_raster_inds
-num_pt_cp = num_cp + 2
-#Import taste selectivity data
-try:
-	select_neur = hf5.pull_data_from_hdf5(hdf5_dir, 'taste_selectivity', 'taste_select_neur_epoch_bin')[0]
-	select_neur = select_neur
-except:
-	print("\tNo taste selectivity data found. Skipping.")
-#Import discriminability data
-peak_epochs = np.squeeze(hf5.pull_data_from_hdf5(hdf5_dir,'taste_discriminability','peak_epochs'))
-discrim_neur = np.squeeze(hf5.pull_data_from_hdf5(hdf5_dir,'taste_discriminability','discrim_neur'))
-#Convert discriminatory neuron changepoint data into pop_taste_cp_raster_inds shape
-#TODO: Add a flag for a user to select whether to use discriminatory neurons or selective neurons
-num_discrim_cp = np.shape(peak_epochs)[0]
-min_cp = np.min((num_pt_cp,num_discrim_cp))
-discrim_cp_raster_inds = []
-for t_i in range(len(dig_in_names)):
-	t_cp_vec = np.ones((np.shape(pop_taste_cp_raster_inds[t_i])[0],num_discrim_cp+1))
-	t_cp_vec = (peak_epochs[:min_cp] + int(pre_taste*1000))*t_cp_vec[:,:min_cp]
-	discrim_cp_raster_inds.append(t_cp_vec)
-discrim_cp_raster_inds = discrim_cp_raster_inds
-discrim_neur = discrim_neur
-
-tastant_fr_dist_pop, taste_num_deliv, max_hz_pop = ddf.taste_fr_dist(num_neur, tastant_spike_times,
-                                                                        discrim_cp_raster_inds,fr_bins,
-                                                                        start_dig_in_times, pre_taste_dt,
-                                                                        post_taste_dt, trial_start_frac)
-tastant_fr_dist_z_pop, taste_num_deliv, max_hz_z_pop, min_hz_z_pop = ddf.taste_fr_dist_zscore(num_neur, tastant_spike_times,
-                                                                                                 segment_spike_times, segment_names,
-                                                                                                 segment_times, discrim_cp_raster_inds,
-                                                                                                 fr_bins,start_dig_in_times, pre_taste_dt,
-                                                                                                 post_taste_dt, bin_dt, trial_start_frac)
-
-print("\tDecoding all neurons")
-decode_dir = bayes_dir + 'All_Neurons/'# + 'gmm/'
-if os.path.isdir(decode_dir) == False:
-	os.mkdir(decode_dir)
-cur_dist = tastant_fr_dist_pop
-select_neur = np.ones(np.shape(discrim_neur))
-
-taste_select_neur = select_neur
-save_dir = decode_dir
-tastant_fr_dist = cur_dist
-max_hz = max_hz_pop
-cp_raster_inds = discrim_cp_raster_inds
-
-#%% Deviation correlation support
-
-dev_dir = metadata['dir_name'] + 'Deviations/'
-hdf5_dir = metadata['hdf5_dir']
-comp_dir = metadata['dir_name'] + 'dev_x_taste/'
-if os.path.isdir(comp_dir) == False:
-	os.mkdir(comp_dir)
-corr_dir = comp_dir + 'corr/'
-if os.path.isdir(corr_dir) == False:
-	os.mkdir(corr_dir)
-#Params/Variables
-num_neur = data_dict['num_neur']
-pre_taste = metadata['params_dict']['pre_taste']
-post_taste = metadata['params_dict']['post_taste']
-epochs_to_analyze = metadata['params_dict']['epochs_to_analyze']
-segments_to_analyze = metadata['params_dict']['segments_to_analyze']
-segment_names = data_dict['segment_names']
-num_segments = len(segment_names)
-segment_spike_times = data_dict['segment_spike_times']
-segment_times = data_dict['segment_times']
-segment_times_reshaped = [[segment_times[i],segment_times[i+1]] for i in range(num_segments)]
-num_cp = metadata['params_dict']['num_cp'] #Remember this is 1 less than the number of epochs
-tastant_spike_times = data_dict['tastant_spike_times']
-start_dig_in_times = data_dict['start_dig_in_times']
-end_dig_in_times = data_dict['end_dig_in_times']
-dig_in_names = data_dict['dig_in_names']
-z_bin = metadata['params_dict']['z_bin']
-
-print("\tNow importing calculated deviations")
-segment_deviations = []
-for s_i in tqdm.tqdm(segments_to_analyze):
-	filepath = dev_dir + segment_names[s_i] + '/deviations.json'
-	with gzip.GzipFile(filepath, mode="r") as f:
-		json_bytes = f.read()
-		json_str = json_bytes.decode('utf-8')			
-		data = json.loads(json_str) 
-		segment_deviations.append(data)
-print("\tNow pulling true deviation rasters")
-num_segments = len(segments_to_analyze)
-segment_spike_times = [segment_spike_times[i] for i in segments_to_analyze]
-segment_times_reshaped = np.array([segment_times_reshaped[i] for i in segments_to_analyze])
-segment_dev_rasters, segment_dev_times, segment_dev_vec, segment_dev_vec_zscore = df.create_dev_rasters(num_segments, 
-															segment_spike_times,
-															segment_times_reshaped,
-															segment_deviations,z_bin)
-
-data_group_name = 'changepoint_data'
-pop_taste_cp_raster_inds = hf5.pull_data_from_hdf5(hdf5_dir,data_group_name,'pop_taste_cp_raster_inds')
-pop_taste_cp_raster_inds = pop_taste_cp_raster_inds
-num_pt_cp = num_cp + 2
-#Import discriminability data
-data_group_name = 'taste_discriminability'
-peak_epochs = np.squeeze(hf5.pull_data_from_hdf5(hdf5_dir,data_group_name,'peak_epochs'))
-discrim_neur = np.squeeze(hf5.pull_data_from_hdf5(hdf5_dir,data_group_name,'discrim_neur'))
-#Convert discriminatory neuron data into pop_taste_cp_raster_inds shape
-#TODO: Test this first, then if going with this rework functions to fit instead!
-num_discrim_cp = np.shape(discrim_neur)[0]
-discrim_cp_raster_inds = []
-for t_i in range(len(dig_in_names)):
-	t_cp_vec = np.ones((np.shape(pop_taste_cp_raster_inds[t_i])[0],num_discrim_cp))
-	t_cp_vec = (peak_epochs[:num_pt_cp] + int(pre_taste*1000))*t_cp_vec
-	discrim_cp_raster_inds.append(t_cp_vec)
-num_discrim_cp = len(peak_epochs)
-
-current_corr_dir = corr_dir + 'all_neur/'
-if os.path.isdir(current_corr_dir) == False:
-	os.mkdir(current_corr_dir)
-#neuron_keep_indices = np.ones((num_neur,num_cp+1))
-neuron_keep_indices = np.ones(np.shape(discrim_neur))
-
-#%% Null dev corr
-
-#These directories should already exist
-hdf5_dir = metadata['hdf5_dir']
-null_dir = metadata['dir_name'] + 'null_data/'
-dev_dir = metadata['dir_name'] + 'Deviations/'
-comp_dir = metadata['dir_name'] + 'dev_x_taste/'
-if os.path.isdir(comp_dir) == False:
-    os.mkdir(comp_dir)
-corr_dir = comp_dir + 'corr/'
-if os.path.isdir(corr_dir) == False:
-    os.mkdir(corr_dir)
-
-num_neur = data_dict['num_neur']
-tastant_spike_times = data_dict['tastant_spike_times']
-start_dig_in_times = data_dict['start_dig_in_times']
-end_dig_in_times = data_dict['end_dig_in_times']
-dig_in_names = data_dict['dig_in_names']
-segment_names = data_dict['segment_names']
-num_segments = len(segment_names)
-pre_taste = metadata['params_dict']['pre_taste']
-post_taste = metadata['params_dict']['post_taste']
-# Import changepoint data
-num_cp = metadata['params_dict']['num_cp'] + 1
-data_group_name = 'changepoint_data'
-pop_taste_cp_raster_inds = hf5.pull_data_from_hdf5(
-    hdf5_dir, data_group_name, 'pop_taste_cp_raster_inds')
-pop_taste_cp_raster_inds = pop_taste_cp_raster_inds
-data_group_name = 'taste_discriminability'
-discrim_neur = np.squeeze(hf5.pull_data_from_hdf5(
-    hdf5_dir, data_group_name, 'discrim_neur'))
-num_discrim_cp = np.shape(discrim_neur)[0]
-discrim_cp_raster_inds = []
-for t_i in range(len(dig_in_names)):
-    t_cp_vec = np.ones(
-        (np.shape(pop_taste_cp_raster_inds[t_i])[0], num_discrim_cp))
-    t_cp_vec = (peak_epochs[:num_cp] +
-                int(pre_taste*1000))*t_cp_vec
-    discrim_cp_raster_inds.append(t_cp_vec)
-num_null = metadata['params_dict']['num_null']
-segments_to_analyze = metadata['params_dict']['segments_to_analyze']
-segment_names = data_dict['segment_names']
 segment_times = data_dict['segment_times']
 segment_times_reshaped = [
     [segment_times[i], segment_times[i+1]] for i in range(num_segments)]
+# Remember this is 1 less than the number of epochs
+num_cp = metadata['params_dict']['num_cp'] + 1
+tastant_spike_times = data_dict['tastant_spike_times']
+start_dig_in_times = data_dict['start_dig_in_times']
+end_dig_in_times = data_dict['end_dig_in_times']
+dig_in_names = data_dict['dig_in_names']
+bin_size = metadata['params_dict']['min_dev_size'] #Use the same minimal size as deviation events
 z_bin = metadata['params_dict']['z_bin']
+data_group_name = 'changepoint_data'
+pop_taste_cp_raster_inds = hf5.pull_data_from_hdf5(
+    hdf5_dir, data_group_name, 'pop_taste_cp_raster_inds')
+data_group_name = 'taste_discriminability'
+discrim_neur = np.squeeze(hf5.pull_data_from_hdf5(
+    hdf5_dir, data_group_name, 'discrim_neur'))
 
-try:  # test if the data exists by trying to import the last from each segment
-    null_i = num_null - 1
-    for s_i in tqdm.tqdm(segments_to_analyze):
-        filepath = dev_dir + 'null_data/' + \
-             segment_names[s_i] + '/null_' + \
-                 str(null_i) + '_deviations.json'
-        with gzip.GzipFile(filepath, mode="r") as f:
-            json_bytes = f.read()
-            json_str = json_bytes.decode('utf-8')
-            data = json.loads(json_str)
-except:
-    print("ERROR! ERROR! ERROR!")
-    print("Null deviations were not calculated previously as expected.")
-    print("Something went wrong in the analysis pipeline.")
-    print("Please try reverting your analysis_state_tracker.csv to 2 to rerun.")
-    print("If issues persist, contact Hannah.")
-    #sys.exit()
 
-print("\tNow importing calculated null deviations")
-all_null_deviations = []
-for null_i in tqdm.tqdm(range(num_null)):
-     null_segment_deviations = []
-     for s_i in segments_to_analyze:
-         filepath = dev_dir + 'null_data/' + \
-             segment_names[s_i] + '/null_' + \
-             str(null_i) + '_deviations.json'
-         with gzip.GzipFile(filepath, mode="r") as f:
-             json_bytes = f.read()
-             json_str = json_bytes.decode('utf-8')
-             data = json.loads(json_str)
-             null_segment_deviations.append(data)
-     all_null_deviations.append(null_segment_deviations)
-del null_i, null_segment_deviations, s_i, filepath, json_bytes, json_str, data
+print("\tNow calculating binned activity")
+bin_times, bin_pop_fr, bin_fr_vecs, bin_fr_vecs_zscore = af.get_bin_activity(segment_times_reshaped,
+                                                             segment_spike_times, bin_size, 
+                                                             segments_to_analyze, False)
 
-print('\tCalculating null distribution spike times')
-# _____Grab null dataset spike times_____
-all_null_segment_spike_times = []
-for null_i in tqdm.tqdm(range(num_null)):
-    null_segment_spike_times = []
-    
-    for s_i in segments_to_analyze:
-        seg_null_dir = null_dir + segment_names[s_i] + '/'
-        # Import the null distribution into memory
-        filepath = seg_null_dir + 'null_' + str(null_i) + '.json'
-        with gzip.GzipFile(filepath, mode="r") as f:
-            json_bytes = f.read()
-            json_str = json_bytes.decode('utf-8')
-            data = json.loads(json_str)
-
-        seg_null_dir = null_dir + segment_names[s_i] + '/'
-
-        seg_start = segment_times_reshaped[s_i][0]
-        seg_end = segment_times_reshaped[s_i][1]
-        null_seg_st = []
-        for n_i in range(num_neur):
-            seg_spike_inds = np.where(
-                (data[n_i] >= seg_start)*(data[n_i] <= seg_end))[0]
-            null_seg_st.append(
-                list(np.array(data[n_i])[seg_spike_inds]))
-        null_segment_spike_times.append(null_seg_st)
-    all_null_segment_spike_times.append(null_segment_spike_times)
-all_null_segment_spike_times = all_null_segment_spike_times
-
-print("\tNow pulling null deviation firing rate vectors")
-num_seg = len(segments_to_analyze)
-seg_times_reshaped = np.array(segment_times_reshaped)[
-    segments_to_analyze, :]
-
-null_dev_vecs = []
-null_dev_vecs_zscore = []
-for s_i in range(num_seg):
-    null_dev_vecs.append([])
-    null_dev_vecs_zscore.append([])
-for null_i in tqdm.tqdm(range(num_null)):
-    null_segment_deviations = all_null_deviations[null_i]
-    null_segment_spike_times = all_null_segment_spike_times[null_i]
-    _, _, null_segment_dev_vecs_i, null_segment_dev_vecs_zscore_i = df.create_dev_rasters(num_seg,
-                                                             null_segment_spike_times,
-                                                             seg_times_reshaped,
-                                                             null_segment_deviations,
-                                                             z_bin, no_z = False)
-    #Compiled all into a single segment group, rather than keeping separated by null dist
-    for s_i in range(num_seg):
-        null_dev_vecs[s_i].extend(null_segment_dev_vecs_i[s_i])
-        null_dev_vecs_zscore[s_i].extend(null_segment_dev_vecs_zscore_i[s_i])
-
-current_corr_dir = corr_dir + 'all_neur/' + 'null/'
-if os.path.isdir(current_corr_dir) == False:
-    os.mkdir(current_corr_dir)
+corr_dir = os.path.join(slide_dir,'all_neur')
+if os.path.isdir(corr_dir) == False:
+    os.mkdir(corr_dir)
 neuron_keep_indices = np.ones(np.shape(discrim_neur))
-# Calculate correlations
-df.calculate_vec_correlations(num_neur, null_dev_vecs, tastant_spike_times,
+
+df.calculate_vec_correlations(num_neur, bin_fr_vecs, tastant_spike_times,
                               start_dig_in_times, end_dig_in_times, segment_names,
                               dig_in_names, pre_taste, post_taste, pop_taste_cp_raster_inds,
-                              current_corr_dir, neuron_keep_indices, segments_to_analyze)  # For all neurons in dataset
+                              corr_dir, neuron_keep_indices, segments_to_analyze)  # For all neurons in dataset
 
-
-import functions.dev_plot_funcs as dpf
-print('\tPlotting null correlation distributions')
-plot_dir = current_corr_dir + 'plots/'
+plot_dir = os.path.join(corr_dir,'plots/')
 if os.path.isdir(plot_dir) == False:
     os.mkdir(plot_dir)
-plot_dir = plot_dir
-corr_dev_stats = df.pull_corr_dev_stats(
-    segment_names, dig_in_names, current_corr_dir, segments_to_analyze)
-dpf.plot_stats(corr_dev_stats, segment_names, dig_in_names, plot_dir,
-               'Correlation', neuron_keep_indices, segments_to_analyze)
-segment_pop_vec_data = dpf.plot_combined_stats(corr_dev_stats, segment_names, dig_in_names,
-                                               plot_dir, 'Correlation', neuron_keep_indices, segments_to_analyze)
-null_corr_percentiles = df.null_dev_corr_90_percentiles(corr_dev_stats, segment_names, dig_in_names, 
-                                 current_corr_dir, segments_to_analyze)
+
+corr_slide_stats = df.pull_corr_dev_stats(
+     segment_names, dig_in_names, corr_dir, 
+     segments_to_analyze, False)
+
+spf.slide_corr_vs_rate(corr_slide_stats,bin_times,bin_pop_fr,num_cp,plot_dir,
+                       corr_dir,segment_names,dig_in_names,segments_to_analyze)
 

--- a/utils/test_support.py
+++ b/utils/test_support.py
@@ -105,6 +105,7 @@ discrim_neur = np.squeeze(hf5.pull_data_from_hdf5(
 
 
 print("\tNow calculating binned activity")
+
 bin_times, bin_pop_fr, bin_fr_vecs, bin_fr_vecs_zscore = af.get_bin_activity(segment_times_reshaped,
                                                              segment_spike_times, bin_size, 
                                                              segments_to_analyze, False)
@@ -130,3 +131,31 @@ corr_slide_stats = df.pull_corr_dev_stats(
 spf.slide_corr_vs_rate(corr_slide_stats,bin_times,bin_pop_fr,num_cp,plot_dir,
                        corr_dir,segment_names,dig_in_names,segments_to_analyze)
 
+spf.top_corr_rate_dist(corr_slide_stats,bin_times,bin_pop_fr,num_cp,plot_dir,
+                       corr_dir,segment_names,dig_in_names,segments_to_analyze)
+
+
+corr_dir = os.path.join(slide_dir,'all_neur_zscore')
+if os.path.isdir(corr_dir) == False:
+    os.mkdir(corr_dir)
+    
+neuron_keep_indices = np.ones(np.shape(discrim_neur))
+
+df.calculate_vec_correlations_zscore(num_neur, z_bin, bin_fr_vecs_zscore, tastant_spike_times,
+                                     segment_times, segment_spike_times, start_dig_in_times, end_dig_in_times,
+                                     segment_names, dig_in_names, pre_taste, post_taste, pop_taste_cp_raster_inds,
+                                     corr_dir, neuron_keep_indices, segments_to_analyze)
+
+plot_dir = os.path.join(corr_dir,'plots/')
+if os.path.isdir(plot_dir) == False:
+    os.mkdir(plot_dir)
+
+corr_slide_stats = df.pull_corr_dev_stats(
+     segment_names, dig_in_names, corr_dir, 
+     segments_to_analyze, False)
+
+spf.slide_corr_vs_rate(corr_slide_stats,bin_times,bin_pop_fr,num_cp,plot_dir,
+                       corr_dir,segment_names,dig_in_names,segments_to_analyze)
+
+spf.top_corr_rate_dist(corr_slide_stats,bin_times,bin_pop_fr,num_cp,plot_dir,
+                       corr_dir,segment_names,dig_in_names,segments_to_analyze)


### PR DESCRIPTION
Added functionality to use sliding bins across rest intervals and calculating correlations to taste responses. Functionality includes calculations for both all neurons regular firing rates and all neurons z-scored firing rates. Further, plot generation added to track trends in correlation distributions / top 90th percentile correlation distributions and their overlap with population firing rates in all bins towards understanding whether there is a correlation between population firing rate and taste information (leading towards deviation analyses).

closes #95 